### PR TITLE
Normalize operator statechart contracts

### DIFF
--- a/contracts/operator/statecharts.schema.json
+++ b/contracts/operator/statecharts.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://riverhog.dev/contracts/operator/statecharts.schema.json",
+  "title": "Riverhog Operator Statecharts",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "statecharts"],
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "statecharts": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/statechart"
+      }
+    },
+    "handoffs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/handoff"
+      }
+    }
+  },
+  "$defs": {
+    "statechart": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["initial", "states"],
+      "properties": {
+        "command": {
+          "enum": ["arc", "arc-disc"]
+        },
+        "initial": {
+          "$ref": "#/$defs/name"
+        },
+        "states": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/state"
+          }
+        }
+      }
+    },
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "enum": ["choice"]
+        },
+        "view": {
+          "$ref": "#/$defs/name"
+        },
+        "event": {
+          "$ref": "#/$defs/eventName"
+        },
+        "action": {
+          "enum": ["arc", "arc-disc"]
+        },
+        "final": {
+          "type": "boolean"
+        },
+        "transitions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/transition"
+          }
+        }
+      }
+    },
+    "transition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target"],
+      "properties": {
+        "guard": {
+          "$ref": "#/$defs/name"
+        },
+        "event": {
+          "$ref": "#/$defs/eventName"
+        },
+        "target": {
+          "$ref": "#/$defs/name"
+        }
+      }
+    },
+    "handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from", "target", "label"],
+      "properties": {
+        "from": {
+          "$ref": "#/$defs/stateRef"
+        },
+        "event": {
+          "$ref": "#/$defs/eventName"
+        },
+        "target": {
+          "$ref": "#/$defs/stateRef"
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "stateRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["statechart", "state"],
+      "properties": {
+        "statechart": {
+          "$ref": "#/$defs/statechartName"
+        },
+        "state": {
+          "$ref": "#/$defs/name"
+        }
+      }
+    },
+    "statechartName": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)*$"
+    },
+    "eventName": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9_.:-]+$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+    }
+  }
+}

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -1,5 +1,4 @@
 version: 1
-
 statecharts:
   arc.home:
     command: arc
@@ -10,6 +9,7 @@ statecharts:
           - guard: non_physical_attention_items
             target: attention_summary
           - target: no_attention
+        type: choice
       attention_summary:
         view: arc_home_attention
         transitions:
@@ -25,14 +25,19 @@ statecharts:
             target: upload_retry_available
       notification_health_failed:
         view: arc_item_notification_health_failed
+        final: true
       setup_needs_attention:
         view: arc_item_setup_needs_attention
+        final: true
       billing_needs_attention:
         view: arc_item_billing_needs_attention
+        final: true
       cloud_backup_failed:
         view: arc_item_cloud_backup_failed
+        final: true
       upload_retry_available:
         view: arc_item_upload_retry_available
+        final: true
       no_attention:
         view: arc_home_no_attention
         transitions:
@@ -40,7 +45,7 @@ statecharts:
             target: at_will_menu
       at_will_menu:
         view: arc_home_at_will_menu
-
+        final: true
   arc.upload:
     command: arc
     initial: prompt_collection_id
@@ -76,11 +81,13 @@ statecharts:
             target: cloud_backup_failed
       finalized:
         view: upload_finalized
+        final: true
       cloud_backup_failed:
         view: upload_failed_cloud_backup
+        final: true
       canceled:
         view: upload_canceled
-
+        final: true
   arc.hot_storage:
     command: arc
     initial: choose_operation
@@ -100,6 +107,7 @@ statecharts:
             target: fetch_detail_pending
           - event: release_pin
             target: release_done
+        type: choice
       search_header:
         view: hot_search_header
         transitions:
@@ -111,10 +119,13 @@ statecharts:
             target: hot_search_no_results
       hot_file_available:
         view: hot_file_available
+        final: true
       hot_file_archived_only:
         view: hot_file_archived_only
+        final: true
       hot_search_no_results:
         view: hot_search_no_results
+        final: true
       get_starting:
         view: get_starting
         transitions:
@@ -124,25 +135,32 @@ statecharts:
             target: get_not_hot
       get_written:
         view: get_written
+        final: true
       get_not_hot:
         view: get_not_hot
+        final: true
       pin_requested:
         transitions:
           - guard: target_available_in_hot_storage
             target: pin_ready
           - guard: disc_recovery_needed
             target: pin_waiting_for_disc
+        type: choice
       pin_ready:
         view: pin_ready
+        final: true
       pin_waiting_for_disc:
         view: pin_waiting_for_disc
+        final: true
       pins_list:
         view: pins_list_header
+        final: true
       fetch_detail_pending:
         view: fetch_detail_pending
+        final: true
       release_done:
         view: release_done
-
+        final: true
   arc.collection_status:
     command: arc
     initial: choose_detail
@@ -157,6 +175,7 @@ statecharts:
             target: images_physical_work_summary
           - event: show_cloud_backup_cost
             target: cloud_backup_report
+        type: choice
       collection_summary:
         view: collection_summary
         transitions:
@@ -167,19 +186,25 @@ statecharts:
           - target: done
       collection_fully_protected:
         view: collection_fully_protected
+        final: true
       collection_needs_attention:
         view: collection_needs_attention
+        final: true
       plan_disc_work:
         transitions:
           - guard: disc_work_ready
             target: plan_disc_work_ready
           - target: plan_no_disc_work
+        type: choice
       plan_disc_work_ready:
         view: plan_disc_work_ready
+        final: true
       plan_no_disc_work:
         view: plan_no_disc_work
+        final: true
       images_physical_work_summary:
         view: images_physical_work_summary
+        final: true
       cloud_backup_report:
         view: cloud_backup_report
         transitions:
@@ -188,8 +213,9 @@ statecharts:
           - target: done
       cloud_backup_billing_detail_unavailable:
         view: cloud_backup_billing_detail_unavailable
-      done: {}
-
+        final: true
+      done:
+        final: true
   arc.copy_management:
     command: arc
     initial: choose_copy_command
@@ -208,19 +234,25 @@ statecharts:
             target: copy_marked_lost
           - event: mark_copy_damaged
             target: copy_marked_damaged
+        type: choice
       copy_registered:
         view: copy_registered
+        final: true
       copy_list_item:
         view: copy_list_item
+        final: true
       copy_moved:
         view: copy_moved
+        final: true
       copy_marked_verified:
         view: copy_marked_verified
+        final: true
       copy_marked_lost:
         view: copy_marked_lost
+        final: true
       copy_marked_damaged:
         view: copy_marked_damaged
-
+        final: true
   arc.maintenance:
     command: arc
     initial: choose_check
@@ -233,21 +265,26 @@ statecharts:
             target: billing_unavailable
           - event: check_notifications
             target: notification_health_failed
+        type: choice
       doctor:
         transitions:
           - guard: setup_is_healthy
             target: doctor_ok
           - guard: setup_needs_attention
             target: doctor_needs_attention
+        type: choice
       doctor_ok:
         view: doctor_ok
+        final: true
       doctor_needs_attention:
         view: doctor_needs_attention
+        final: true
       billing_unavailable:
         view: billing_unavailable
+        final: true
       notification_health_failed:
         view: notification_health_failed
-
+        final: true
   arc_disc.guided:
     command: arc-disc
     initial: scan_backlog
@@ -257,6 +294,7 @@ statecharts:
           - guard: physical_or_recovery_backlog
             target: attention_summary
           - target: no_attention
+        type: choice
       attention_summary:
         view: arc_disc_attention
         transitions:
@@ -276,21 +314,28 @@ statecharts:
             target: recovery_expired
       unfinished_local_disc:
         view: disc_item_unfinished_local_copy
+        final: true
       recovery_ready:
         view: disc_item_recovery_ready
+        final: true
       recovery_approval_required:
         view: disc_item_recovery_approval_required
+        final: true
       hot_recovery_needs_media:
         view: disc_item_hot_recovery_needs_media
+        final: true
       replacement_disc_needed:
         view: disc_item_replacement_disc_needed
+        final: true
       burn_work_ready:
         view: disc_item_burn_work_ready
+        final: true
       recovery_expired:
         view: disc_item_recovery_expired
+        final: true
       no_attention:
         view: arc_disc_no_attention
-
+        final: true
   arc_disc.burn:
     command: arc-disc
     initial: inspect_burn_work
@@ -305,8 +350,10 @@ statecharts:
             target: unlabeled_copy_unavailable
           - guard: blank_disc_work_ready
             target: ready
+        type: choice
       no_work:
         view: burn_no_work
+        final: true
       ready:
         view: burn_ready
         transitions:
@@ -361,7 +408,7 @@ statecharts:
             target: ready
       backlog_cleared:
         view: burn_backlog_cleared
-
+        final: true
   arc_disc.recovery:
     command: arc-disc
     initial: inspect_recovery
@@ -380,6 +427,7 @@ statecharts:
             target: expired
           - guard: recovery_cleanup_handoff_ready
             target: cleanup_handoff
+        type: choice
       approval_required:
         view: recovery_approval_required
         transitions:
@@ -406,11 +454,13 @@ statecharts:
             target: expired
       completed:
         view: recovery_completed
+        final: true
       expired:
         view: recovery_expired
+        final: true
       cleanup_handoff:
         view: recovery_cleanup_handoff
-
+        final: true
   arc_disc.hot_recovery:
     command: arc-disc
     initial: need_media
@@ -419,6 +469,7 @@ statecharts:
         transitions:
           - event: operator_inserts_disc
             target: insert_disc
+        type: choice
       insert_disc:
         view: hot_recovery_insert_disc
         transitions:
@@ -438,7 +489,7 @@ statecharts:
             target: insert_disc
       done:
         view: hot_recovery_done
-
+        final: true
   arc_disc.fetch:
     command: arc-disc
     initial: fetch_requested
@@ -449,6 +500,7 @@ statecharts:
             target: insert_disc
           - guard: upload_already_complete
             target: done
+        type: choice
       insert_disc:
         view: hot_recovery_insert_disc
         transitions:
@@ -468,7 +520,7 @@ statecharts:
             target: insert_disc
       done:
         view: hot_recovery_done
-
+        final: true
   operator.notifications:
     initial: classify_event
     states:
@@ -500,331 +552,343 @@ statecharts:
             target: no_labeling_notification
           - event: routine_success
             target: no_routine_success_notification
+        type: choice
       ready_disc_work:
         event: images.ready
         view: push_burn_work_ready
+        final: true
       disc_work_waiting_too_long:
         event: operator.disc_work_waiting_too_long
         view: push_disc_work_waiting_too_long
+        final: true
       replacement_disc_needed:
         event: operator.replacement_disc_needed
         view: push_replacement_disc_needed
+        final: true
       recovery_approval_required:
         event: operator.recovery_approval_required
         view: push_recovery_approval_required
+        final: true
       recovery_ready:
         event: images.rebuild_ready
         view: push_recovery_ready
+        final: true
       hot_recovery_needs_media:
         event: operator.hot_recovery_needs_media
         view: push_hot_recovery_needs_media
+        final: true
       cloud_backup_failed:
         event: collections.glacier_upload.failed
         view: push_cloud_backup_failed
+        final: true
       notification_health_failed:
         event: operator.notification_health_failed
         view: push_notification_health_failed
+        final: true
       billing_needs_attention:
         event: operator.billing_needs_attention
         view: push_billing_needs_attention
+        final: true
       setup_needs_attention:
         event: operator.setup_needs_attention
         view: push_setup_needs_attention
-      no_labeling_notification: {}
-      no_routine_success_notification: {}
-
-links:
+        final: true
+      no_labeling_notification:
+        final: true
+      no_routine_success_notification:
+        final: true
+handoffs:
   - from:
       statechart: arc.home
       state: at_will_menu
     label: operator chooses upload
-    to:
+    target:
       statechart: arc.upload
       state: prompt_collection_id
   - from:
       statechart: arc.home
       state: at_will_menu
     label: operator chooses hot storage
-    to:
+    target:
       statechart: arc.hot_storage
       state: choose_operation
   - from:
       statechart: arc.home
       state: at_will_menu
     label: operator chooses collection status
-    to:
+    target:
       statechart: arc.collection_status
       state: choose_detail
   - from:
       statechart: arc.home
       state: at_will_menu
     label: operator chooses copy management
-    to:
+    target:
       statechart: arc.copy_management
       state: choose_copy_command
   - from:
       statechart: arc.home
       state: at_will_menu
     label: operator chooses maintenance
-    to:
+    target:
       statechart: arc.maintenance
       state: choose_check
   - from:
       statechart: arc.home
       state: notification_health_failed
     label: operator reviews notification health
-    to:
+    target:
       statechart: arc.maintenance
       state: choose_check
   - from:
       statechart: arc.home
       state: setup_needs_attention
     label: operator reviews setup health
-    to:
+    target:
       statechart: arc.maintenance
       state: choose_check
   - from:
       statechart: arc.home
       state: billing_needs_attention
     label: operator reviews recovery costs
-    to:
+    target:
       statechart: arc.maintenance
       state: choose_check
   - from:
       statechart: arc.home
       state: upload_retry_available
     label: operator retries upload
-    to:
+    target:
       statechart: arc.upload
       state: prompt_collection_id
   - from:
       statechart: arc.upload
       state: finalized
     label: operator reviews collection status
-    to:
+    target:
       statechart: arc.collection_status
       state: choose_detail
   - from:
       statechart: arc.upload
       state: cloud_backup_failed
     label: failure becomes home attention
-    to:
+    target:
       statechart: arc.home
       state: scan_attention
   - from:
       statechart: arc.hot_storage
       state: pin_waiting_for_disc
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc.hot_storage
       state: fetch_detail_pending
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc.collection_status
       state: plan_disc_work_ready
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc.collection_status
       state: images_physical_work_summary
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc.copy_management
       state: copy_registered
     label: operator reviews collection status
-    to:
+    target:
       statechart: arc.collection_status
       state: choose_detail
   - from:
       statechart: arc.copy_management
       state: copy_marked_verified
     label: operator reviews collection status
-    to:
+    target:
       statechart: arc.collection_status
       state: choose_detail
   - from:
       statechart: arc.copy_management
       state: copy_marked_lost
     label: replacement may be needed
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc.copy_management
       state: copy_marked_damaged
     label: replacement may be needed
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc_disc.guided
       state: unfinished_local_disc
     label: operator resumes burn flow
-    to:
+    target:
       statechart: arc_disc.burn
       state: inspect_burn_work
   - from:
       statechart: arc_disc.guided
       state: burn_work_ready
     label: operator starts burn flow
-    to:
+    target:
       statechart: arc_disc.burn
       state: inspect_burn_work
   - from:
       statechart: arc_disc.guided
       state: recovery_ready
     label: operator reviews recovery flow
-    to:
+    target:
       statechart: arc_disc.recovery
       state: inspect_recovery
   - from:
       statechart: arc_disc.guided
       state: recovery_approval_required
     label: operator reviews recovery flow
-    to:
+    target:
       statechart: arc_disc.recovery
       state: inspect_recovery
   - from:
       statechart: arc_disc.guided
       state: recovery_expired
     label: operator reviews recovery flow
-    to:
+    target:
       statechart: arc_disc.recovery
       state: inspect_recovery
   - from:
       statechart: arc_disc.guided
       state: replacement_disc_needed
     label: operator reviews recovery flow
-    to:
+    target:
       statechart: arc_disc.recovery
       state: inspect_recovery
   - from:
       statechart: arc_disc.guided
       state: hot_recovery_needs_media
     label: operator restores hot storage
-    to:
+    target:
       statechart: arc_disc.hot_recovery
       state: need_media
   - from:
       statechart: arc_disc.burn
       state: backlog_cleared
     label: operator checks remaining disc work
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc_disc.recovery
       state: completed
     label: operator checks remaining recovery work
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc_disc.recovery
       state: expired
     label: operator checks remaining recovery work
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc_disc.recovery
       state: cleanup_handoff
     label: operator checks remaining recovery work
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: arc_disc.hot_recovery
       state: done
     label: restored file returns to hot storage
-    to:
+    target:
       statechart: arc.hot_storage
       state: choose_operation
   - from:
       statechart: arc_disc.fetch
       state: done
     label: restored fetch returns to hot storage
-    to:
+    target:
       statechart: arc.hot_storage
       state: choose_operation
   - from:
       statechart: operator.notifications
       state: ready_disc_work
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: operator.notifications
       state: disc_work_waiting_too_long
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: operator.notifications
       state: replacement_disc_needed
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: operator.notifications
       state: recovery_approval_required
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: operator.notifications
       state: recovery_ready
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: operator.notifications
       state: hot_recovery_needs_media
     label: operator runs arc-disc
-    to:
+    target:
       statechart: arc_disc.guided
       state: scan_backlog
   - from:
       statechart: operator.notifications
       state: cloud_backup_failed
     label: operator runs arc
-    to:
+    target:
       statechart: arc.home
       state: scan_attention
   - from:
       statechart: operator.notifications
       state: notification_health_failed
     label: operator runs arc
-    to:
+    target:
       statechart: arc.home
       state: scan_attention
   - from:
       statechart: operator.notifications
       state: billing_needs_attention
     label: operator runs arc
-    to:
+    target:
       statechart: arc.home
       state: scan_attention
   - from:
       statechart: operator.notifications
       state: setup_needs_attention
     label: operator runs arc
-    to:
+    target:
       statechart: arc.home
       state: scan_attention

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -38,17 +38,17 @@ def load_contract(
     if contract.get("version") != 1:
         raise StatechartContractError("statechart contract version must be 1")
     statecharts = _mapping(contract.get("statecharts"), label="statecharts")
-    links = contract.get("links", [])
-    if not isinstance(links, Sequence) or isinstance(links, str):
-        raise StatechartContractError("links must be a list")
+    handoffs = contract.get("handoffs", [])
+    if not isinstance(handoffs, Sequence) or isinstance(handoffs, str):
+        raise StatechartContractError("handoffs must be a list")
     return {
         str(name): _mapping(statechart, label=f"statecharts.{name}")
         for name, statechart in statecharts.items()
-    }, [_mapping(link, label="links[]") for link in links]
+    }, [_mapping(handoff, label="handoffs[]") for handoff in handoffs]
 
 
 def load_statecharts(path: Path = DEFAULT_CONTRACT) -> Mapping[str, Mapping[str, Any]]:
-    statecharts, _links = load_contract(path)
+    statecharts, _handoffs = load_contract(path)
     return statecharts
 
 
@@ -131,16 +131,16 @@ def _state_node_line(state_name: str, label: str) -> str:
     return f'    {state_name}["{label}"]:::stateNode'
 
 
-def _link_endpoint(link: Mapping[str, Any], key: str) -> tuple[str, str]:
-    endpoint = _mapping(link.get(key), label=f"links[].{key}")
+def _handoff_endpoint(handoff: Mapping[str, Any], key: str) -> tuple[str, str]:
+    endpoint = _mapping(handoff.get(key), label=f"handoffs[].{key}")
     return str(endpoint.get("statechart", "")), str(endpoint.get("state", ""))
 
 
-def _link_label(link: Mapping[str, Any]) -> str:
-    label = link.get("label")
+def _handoff_label(handoff: Mapping[str, Any]) -> str:
+    label = handoff.get("label")
     if not label:
-        from_statechart, _from_state = _link_endpoint(link, "from")
-        to_statechart, _to_state = _link_endpoint(link, "to")
+        from_statechart, _from_state = _handoff_endpoint(handoff, "from")
+        to_statechart, _to_state = _handoff_endpoint(handoff, "target")
         label = f"{from_statechart} to {to_statechart}"
     return _transition_display_label(str(label))
 
@@ -676,25 +676,25 @@ def _transition_lines_for(
     return lines, transition_nodes
 
 
-def _link_lines_for(
+def _handoff_lines_for(
     *,
     statechart_name: str,
     states: Mapping[str, Any],
     statecharts: Mapping[str, Mapping[str, Any]],
-    links: Sequence[Mapping[str, Any]],
+    handoffs: Sequence[Mapping[str, Any]],
 ) -> list[str]:
     lines: list[str] = []
-    link_nodes: list[tuple[str, str]] = []
+    handoff_nodes: list[tuple[str, str]] = []
     external_nodes: dict[tuple[str, str], str] = {}
 
-    for link in links:
-        from_statechart, from_state = _link_endpoint(link, "from")
+    for handoff in handoffs:
+        from_statechart, from_state = _handoff_endpoint(handoff, "from")
         if from_statechart != statechart_name:
             continue
-        to_statechart, to_state = _link_endpoint(link, "to")
+        to_statechart, to_state = _handoff_endpoint(handoff, "target")
         if from_state not in states:
             raise StatechartContractError(
-                f"link source state does not exist: {from_statechart}.{from_state}"
+                f"handoff source state does not exist: {from_statechart}.{from_state}"
             )
         target_statechart = _mapping(
             statecharts.get(to_statechart),
@@ -706,7 +706,7 @@ def _link_lines_for(
         )
         if to_state not in target_states:
             raise StatechartContractError(
-                f"link target state does not exist: {to_statechart}.{to_state}"
+                f"handoff target state does not exist: {to_statechart}.{to_state}"
             )
 
         link_id = _link_node_id(
@@ -720,11 +720,11 @@ def _link_lines_for(
         )
         lines.append(f"    {from_state} --> {link_id}")
         lines.append(f"    {link_id} --> {external_id}")
-        link_nodes.append((link_id, _link_label(link)))
+        handoff_nodes.append((link_id, _handoff_label(handoff)))
 
-    if link_nodes:
+    if handoff_nodes:
         lines.append("")
-        for link_id, label in link_nodes:
+        for link_id, label in handoff_nodes:
             lines.append(_link_node_line(link_id, label))
         for (to_statechart, to_state), external_id in external_nodes.items():
             lines.append(
@@ -742,7 +742,7 @@ def render_statechart(
     statechart: Mapping[str, Any],
     *,
     statecharts: Mapping[str, Mapping[str, Any]] | None = None,
-    links: Sequence[Mapping[str, Any]] = (),
+    handoffs: Sequence[Mapping[str, Any]] = (),
 ) -> str:
     states = _mapping(statechart.get("states"), label=f"{name}.states")
     initial = str(statechart.get("initial", ""))
@@ -782,15 +782,15 @@ def render_statechart(
         lines.append("")
 
     if statecharts is not None:
-        link_lines = _link_lines_for(
+        handoff_lines = _handoff_lines_for(
             statechart_name=name,
             states=states,
             statecharts=statecharts,
-            links=links,
+            handoffs=handoffs,
         )
-        if link_lines:
+        if handoff_lines:
             lines.append("")
-            lines.extend(link_lines)
+            lines.extend(handoff_lines)
 
     lines.append("")
     lines.extend(_class_def_lines(initial))
@@ -823,7 +823,7 @@ def _write_outputs(
     *,
     out_dir: Path,
     statecharts: Mapping[str, Mapping[str, Any]],
-    links: Sequence[Mapping[str, Any]],
+    handoffs: Sequence[Mapping[str, Any]],
 ) -> list[Path]:
     out_dir.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
@@ -834,7 +834,7 @@ def _write_outputs(
                 name,
                 statechart,
                 statecharts=statecharts,
-                links=links,
+                handoffs=handoffs,
             ),
             encoding="utf-8",
         )
@@ -865,14 +865,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        statecharts, links = load_contract(args.contract)
+        statecharts, handoffs = load_contract(args.contract)
         selected = _selected_statecharts(statecharts, args.statecharts)
         if args.out_dir:
             for path in _write_outputs(
                 selected,
                 out_dir=args.out_dir,
                 statecharts=statecharts,
-                links=links,
+                handoffs=handoffs,
             ):
                 print(path)
             return 0
@@ -881,7 +881,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 name,
                 statechart,
                 statecharts=statecharts,
-                links=links,
+                handoffs=handoffs,
             ).rstrip()
             for name, statechart in selected
         ]

--- a/tests/unit/test_operator_statecharts.py
+++ b/tests/unit/test_operator_statecharts.py
@@ -9,12 +9,14 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from jsonschema import Draft202012Validator
 
 from contracts.operator import copy as operator_copy
 
 ROOT = Path(__file__).resolve().parents[2]
 FEATURES_DIR = ROOT / "tests" / "acceptance" / "features"
 STATECHARTS_CONTRACT = ROOT / "contracts" / "operator" / "statecharts.yaml"
+STATECHARTS_SCHEMA = ROOT / "contracts" / "operator" / "statecharts.schema.json"
 MERMAID_GENERATOR = ROOT / "scripts" / "fsm_to_mermaid.py"
 MERMAID_PUPPETEER_CONFIG = ROOT / "scripts" / "mermaid-puppeteer-config.json"
 MERMAID_CLI_PACKAGE = "@mermaid-js/mermaid-cli@8.14.0"
@@ -38,14 +40,20 @@ def _statecharts() -> dict[str, dict[str, Any]]:
     return statecharts
 
 
-def _links() -> list[dict[str, Any]]:
-    links = _contract()["links"]
-    assert isinstance(links, list)
-    return links
+def _schema() -> dict[str, Any]:
+    schema = yaml.safe_load(STATECHARTS_SCHEMA.read_text(encoding="utf-8"))
+    assert isinstance(schema, dict)
+    return schema
 
 
-def _endpoint(link: dict[str, Any], key: str) -> tuple[str, str]:
-    endpoint = link[key]
+def _handoffs() -> list[dict[str, Any]]:
+    handoffs = _contract()["handoffs"]
+    assert isinstance(handoffs, list)
+    return handoffs
+
+
+def _endpoint(handoff: dict[str, Any], key: str) -> tuple[str, str]:
+    endpoint = handoff[key]
     assert isinstance(endpoint, dict)
     return str(endpoint["statechart"]), str(endpoint["state"])
 
@@ -145,38 +153,72 @@ def test_statechart_contract_has_valid_initials_and_transition_targets() -> None
 
         for state_name, state in states.items():
             assert isinstance(state, dict), f"{name}.{state_name}"
-            assert "final" not in state, f"{name}.{state_name}"
-            assert "action" not in state, f"{name}.{state_name}"
+            assert state.get("action") in (None, "arc", "arc-disc"), f"{name}.{state_name}"
             transitions = state.get("transitions", [])
             assert isinstance(transitions, list), f"{name}.{state_name}"
             for transition in transitions:
                 assert isinstance(transition, dict), f"{name}.{state_name}"
-                assert "action" not in transition, f"{name}.{state_name}"
                 assert len({"event", "guard"} & transition.keys()) <= 1
                 assert transition.get("target") in states, f"{name}.{state_name}"
 
 
-def test_statechart_links_resolve_between_contract_states() -> None:
-    statecharts = _statecharts()
-    links = _links()
+def test_statechart_contract_matches_json_schema() -> None:
+    Draft202012Validator.check_schema(_schema())
+    validator = Draft202012Validator(_schema())
+    errors = sorted(validator.iter_errors(_contract()), key=lambda error: error.json_path)
+    assert not errors
 
-    assert links
-    for index, link in enumerate(links):
-        assert set(link) == {"from", "label", "to"}, index
-        assert isinstance(link.get("label"), str), index
-        assert link["label"].strip(), index
+
+def test_statechart_handoffs_resolve_between_contract_states() -> None:
+    statecharts = _statecharts()
+    handoffs = _handoffs()
+
+    assert handoffs
+    for index, handoff in enumerate(handoffs):
+        assert set(handoff) <= {"from", "event", "label", "target"}, index
+        assert {"from", "label", "target"} <= set(handoff), index
+        assert isinstance(handoff.get("label"), str), index
+        assert handoff["label"].strip(), index
         endpoints: dict[str, tuple[str, str]] = {}
-        for key in ("from", "to"):
-            endpoint = link[key]
+        for key in ("from", "target"):
+            endpoint = handoff[key]
             assert isinstance(endpoint, dict), index
             assert set(endpoint) == {"statechart", "state"}, f"{index}.{key}"
-            statechart_name, state_name = _endpoint(link, key)
+            statechart_name, state_name = _endpoint(handoff, key)
             endpoints[key] = (statechart_name, state_name)
             assert statechart_name in statecharts, f"{index}.{key}"
             states = statecharts[statechart_name]["states"]
             assert isinstance(states, dict)
             assert state_name in states, f"{index}.{key}"
-        assert endpoints["from"] != endpoints["to"], index
+        assert endpoints["from"] != endpoints["target"], index
+
+
+def test_statechart_choice_states_are_routing_states() -> None:
+    for statechart_name, statechart in _statecharts().items():
+        states = statechart["states"]
+        assert isinstance(states, dict)
+        for state_name, state in states.items():
+            assert isinstance(state, dict)
+            if state.get("type") != "choice":
+                continue
+            assert state.get("transitions"), f"{statechart_name}.{state_name}"
+            assert state.get("final") is not True, f"{statechart_name}.{state_name}"
+            assert "event" not in state, f"{statechart_name}.{state_name}"
+            assert "action" not in state, f"{statechart_name}.{state_name}"
+
+
+def test_statechart_terminal_states_are_marked_final() -> None:
+    for statechart_name, statechart in _statecharts().items():
+        states = statechart["states"]
+        assert isinstance(states, dict)
+        for state_name, state in states.items():
+            assert isinstance(state, dict)
+            transitions = state.get("transitions", [])
+            assert isinstance(transitions, list), f"{statechart_name}.{state_name}"
+            if transitions:
+                assert state.get("final") is not True, f"{statechart_name}.{state_name}"
+                continue
+            assert state.get("final") is True, f"{statechart_name}.{state_name}"
 
 
 def test_statechart_views_resolve_to_operator_copy_contract() -> None:


### PR DESCRIPTION
## Summary
- add JSON Schema coverage for `contracts/operator/statecharts.yaml`
- normalize operator statecharts with explicit `type: choice`, `final: true`, and root-level `handoffs`
- update Mermaid generation and unit checks for the normalized contract vocabulary

## Validation
- `make lint`
- `make unit` -> 255 passed
- targeted `make spec` -> 3 passed
- targeted `make prod` -> expected skip/xfails only
- canonical `make spec` -> 167 passed
- canonical `make prod` -> 127 passed, 22 skipped, 18 xfailed

Fixes #215
Fixes #216
