### PR TITLE
Meta: Name next disc labels after failed media work

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -772,10 +772,18 @@ def hot_recovery_progress(
     )
 
 
-def hot_recovery_retry_other_disc(*, target: str) -> str:
+def hot_recovery_retry_other_disc(*, target: str, next_disc_label: str) -> str:
     return (
         f"Riverhog could not restore {truncate(target)} from that disc. "
-        "Try another registered disc or recovered media."
+        f"Locate disc label {next_disc_label} for the same image and insert it next."
+    )
+
+
+def hot_recovery_registered_copies_exhausted(*, target: str) -> str:
+    return (
+        f"Riverhog tried every registered disc copy that can restore {truncate(target)}. "
+        "Mark the failed copies as damaged if needed, then use the recovery workflow "
+        "before retrying from recovered media."
     )
 
 

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -479,13 +479,18 @@ statecharts:
         transitions:
           - guard: restore_complete
             target: done
-          - guard: disc_cannot_restore_requested_files
+          - guard: untried_same_image_copy_available
             target: retry_other_disc
+          - guard: same_image_registered_copies_exhausted
+            target: recovery_workflow_needed
       retry_other_disc:
         view: hot_recovery_retry_other_disc
         transitions:
-          - event: operator_inserts_another_disc
+          - event: operator_inserts_named_disc
             target: insert_disc
+      recovery_workflow_needed:
+        view: hot_recovery_registered_copies_exhausted
+        final: true
       done:
         view: hot_recovery_done
         final: true
@@ -510,13 +515,18 @@ statecharts:
         transitions:
           - guard: server_accepts_recovered_bytes
             target: done
-          - guard: server_rejects_recovered_bytes
+          - guard: rejected_bytes_untried_same_image_copy_available
             target: retry_other_disc
+          - guard: rejected_bytes_same_image_registered_copies_exhausted
+            target: recovery_workflow_needed
       retry_other_disc:
         view: hot_recovery_retry_other_disc
         transitions:
-          - event: operator_retries_with_other_media
+          - event: operator_inserts_named_disc
             target: insert_disc
+      recovery_workflow_needed:
+        view: hot_recovery_registered_copies_exhausted
+        final: true
       done:
         view: hot_recovery_done
         final: true

--- a/docs/how-to/fulfill-a-fetch-from-optical-media.md
+++ b/docs/how-to/fulfill-a-fetch-from-optical-media.md
@@ -26,10 +26,10 @@ If recovery is interrupted after upload has started, the server-side manifest ke
 data is discarded and the manifest returns to `waiting_media`.
 
 If final server verification rejects a `byte_complete` entry, `arc-disc fetch` cancels that entry upload resource before
-exiting. The manifest stays active and incomplete with the rejected entry back at offset `0`. Try another registered copy
-for that entry when one is available. If every registered copy fails, report the
-damaged copies and complete an image rebuild session before running
-`arc-disc fetch` again from recovered media.
+exiting. The manifest stays active and incomplete with the rejected entry back at offset `0`. If another registered copy
+of the same image remains untried, Riverhog names that exact disc label as the next disc to locate and insert. If every
+registered same-image copy fails, report the damaged copies and complete recovery before running `arc-disc fetch` again
+from recovered media.
 
 During fulfillment, `arc-disc` should show:
 

--- a/docs/reference/disc.md
+++ b/docs/reference/disc.md
@@ -163,6 +163,9 @@ Automated multipart recovery uses the fetch manifest as its recovery contract.
 - incomplete upload state expires after `INCOMPLETE_UPLOAD_TTL` since the last accepted chunk and the manifest returns to
   `waiting_media`
 - `arc-disc` reports precise progress for the current file and the whole manifest throughout recovery and upload
+- when recovered bytes or requested files cannot be restored from one registered disc, retry guidance names the exact
+  untried same-image copy label; when no such copy remains, guidance routes to recovery instead of asking for vague
+  alternate media
 
 Expected multipart flow:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_301: tracks issue #301 for backing next-disc-label-PM-scenarios",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_301: tracks issue #301 for backing next-disc-label-PM-scenarios",
+  "issue_317: tracks issue #317 for implementing next-disc label retry routing",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -527,7 +527,12 @@ def render_operator_copy(reference: str) -> str:
             )
         case "hot_recovery_retry_other_disc":
             return operator_copy.hot_recovery_retry_other_disc(
-                target="docs/tax/2022/invoice-123.pdf"
+                target="docs/tax/2022/invoice-123.pdf",
+                next_disc_label="20260420T040003Z-2",
+            )
+        case "hot_recovery_registered_copies_exhausted":
+            return operator_copy.hot_recovery_registered_copies_exhausted(
+                target="docs/tax/2022/invoice-123.pdf",
             )
         case "hot_recovery_done":
             return operator_copy.hot_recovery_done(

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,6 +18,7 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
 app = typer.Typer(help="arc optical recovery CLI")
 
@@ -527,6 +528,62 @@ def _prompt_for_disc(copy: RecoveryCopyHint, *, device: str) -> None:
         input()
     except EOFError as exc:  # pragma: no cover - exercised via subprocess acceptance tests
         raise RuntimeError("stdin closed while waiting for disc insertion") from exc
+
+
+def _image_id_from_copy_id(copy_id: str) -> str:
+    image_id, sep, _ordinal = copy_id.rpartition("-")
+    return image_id if sep else copy_id
+
+
+def _next_same_image_copy(
+    part: RecoveryPartHint,
+    failed_copy: RecoveryCopyHint,
+) -> RecoveryCopyHint | None:
+    failed_image_id = _image_id_from_copy_id(failed_copy.copy_id)
+    for copy in part.copies:
+        if copy.copy_id == failed_copy.copy_id:
+            continue
+        if _image_id_from_copy_id(copy.copy_id) == failed_image_id:
+            return copy
+    return None
+
+
+def _next_same_image_copy_for_entry(entry: RecoveryEntry) -> RecoveryCopyHint | None:
+    for part in entry.parts:
+        if not part.copies:
+            continue
+        next_copy = _next_same_image_copy(part, part.copies[0])
+        if next_copy is not None:
+            return next_copy
+    return None
+
+
+def _report_same_image_retry_or_recovery(
+    entry: RecoveryEntry,
+    *,
+    target: str,
+    failed_copy: RecoveryCopyHint | None = None,
+) -> None:
+    next_copy: RecoveryCopyHint | None = None
+    if failed_copy is not None:
+        for part in entry.parts:
+            if failed_copy in part.copies:
+                next_copy = _next_same_image_copy(part, failed_copy)
+                break
+    else:
+        next_copy = _next_same_image_copy_for_entry(entry)
+
+    if next_copy is not None:
+        typer.echo(
+            operator_copy.hot_recovery_retry_other_disc(
+                target=target,
+                next_disc_label=next_copy.copy_id,
+            ),
+            err=True,
+        )
+        return
+
+    typer.echo(operator_copy.hot_recovery_registered_copies_exhausted(target=target), err=True)
 
 
 def _sha256_file(path: Path) -> str:
@@ -1214,6 +1271,7 @@ def _upload_entry_from_disc(
     client: ApiClient,
     reader: Any,
     device: str,
+    target: str,
     progress: ProgressReporter,
 ) -> None:
     offset = session.offset
@@ -1232,22 +1290,26 @@ def _upload_entry_from_disc(
             _iter_recovered_chunks(reader, copy, device=device),
             skip_bytes=resume_within_part,
         )
-        for chunk in recovered_chunks:
-            if not chunk:
-                continue
-            upload_result = client.append_upload_chunk(
-                session.upload_url,
-                offset=offset,
-                checksum_algorithm=session.checksum_algorithm,
-                content=chunk,
-            )
-            next_offset = int(upload_result["offset"])
-            uploaded_bytes = next_offset - offset
-            if uploaded_bytes != len(chunk):
-                raise RuntimeError(f"upload offset advanced unexpectedly for {entry.path}")
-            offset = next_offset
-            progress.record_uploaded_bytes(entry, uploaded_bytes)
-            progress.report(entry)
+        try:
+            for chunk in recovered_chunks:
+                if not chunk:
+                    continue
+                upload_result = client.append_upload_chunk(
+                    session.upload_url,
+                    offset=offset,
+                    checksum_algorithm=session.checksum_algorithm,
+                    content=chunk,
+                )
+                next_offset = int(upload_result["offset"])
+                uploaded_bytes = next_offset - offset
+                if uploaded_bytes != len(chunk):
+                    raise RuntimeError(f"upload offset advanced unexpectedly for {entry.path}")
+                offset = next_offset
+                progress.record_uploaded_bytes(entry, uploaded_bytes)
+                progress.report(entry)
+        except RuntimeError:
+            _report_same_image_retry_or_recovery(entry, target=target, failed_copy=copy)
+            raise
 
         part_start = part_end
 
@@ -1270,18 +1332,7 @@ def _reset_byte_complete_uploads(
         client.cancel_fetch_entry_upload(fetch_id, entry.id)
         reset_entries.append(entry)
         typer.echo(
-            (
-                f"reset byte-complete upload for {entry.path}; "
-                "try another registered copy or recovered media"
-            ),
-            err=True,
-        )
-    if reset_entries:
-        typer.echo(
-            (
-                "fetch remains active and incomplete; if every registered copy fails, "
-                "report the damaged copies and use the Glacier recovery session before retrying"
-            ),
+            f"reset byte-complete upload for {entry.path} after recovered bytes were rejected",
             err=True,
         )
     return reset_entries
@@ -1296,6 +1347,7 @@ def fetch_cmd(
     try:
         client = ApiClient()
         manifest = client.get_fetch_manifest(fetch_id)
+        target = str(manifest.get("target", fetch_id))
         reader = build_optical_reader()
         entries = tuple(_entry_from_manifest(entry) for entry in manifest.get("entries", []))
         sessions = {
@@ -1316,6 +1368,7 @@ def fetch_cmd(
                 client=client,
                 reader=reader,
                 device=device,
+                target=target,
                 progress=progress,
             )
 
@@ -1323,6 +1376,8 @@ def fetch_cmd(
             payload = client.complete_fetch(fetch_id)
         except HashMismatch as exc:
             _reset_byte_complete_uploads(client, fetch_id, entries, progress)
+            for entry in entries:
+                _report_same_image_retry_or_recovery(entry, target=target)
             raise RuntimeError(f"final fetch verification failed: {exc}") from exc
     except (ArcError, RuntimeError) as exc:
         typer.echo(f"error: {exc}", err=True)

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -80,7 +80,7 @@ Feature: arc-disc CLI
       And the collection is not fully protected
 
   Rule: Targeted fetch detail remains available
-  @todo @issue_301
+  @contract_gap @issue_317
   Scenario: arc-disc fetch names the exact same-image disc after rejected bytes
     Given statechart "arc_disc.fetch" state "retry_other_disc" is the accepted operator contract
     And fetch "fx-1" needs copy label "20260420T040003Z-1"
@@ -91,7 +91,7 @@ Feature: arc-disc CLI
     And stderr does not mention "try another registered copy or recovered media"
     And stderr does not mention "20260420T040004Z-1"
 
-  @todo @issue_301
+  @contract_gap @issue_317
   Scenario: arc-disc disc restore names the exact same-image disc after failed media
     Given statechart "arc_disc.hot_recovery" state "retry_other_disc" is the accepted operator contract
     And disc restore needs copy label "20260420T040003Z-1"
@@ -102,7 +102,7 @@ Feature: arc-disc CLI
     And stderr does not mention "try another registered disc or recovered media"
     And stderr does not mention "20260420T040004Z-1"
 
-  @todo @issue_301
+  @contract_gap @issue_317
   Scenario: arc-disc failed media routes to recovery when same-image copies are exhausted
     Given statechart "arc_disc.fetch" state "recovery_workflow_needed" is the accepted operator contract
     And all registered same-image disc labels for fetch "fx-1" have failed

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -80,7 +80,7 @@ Feature: arc-disc CLI
       And the collection is not fully protected
 
   Rule: Targeted fetch detail remains available
-  @todo @issue_226
+  @todo @issue_301
   Scenario: arc-disc fetch names the exact same-image disc after rejected bytes
     Given statechart "arc_disc.fetch" state "retry_other_disc" is the accepted operator contract
     And fetch "fx-1" needs copy label "20260420T040003Z-1"
@@ -91,7 +91,7 @@ Feature: arc-disc CLI
     And stderr does not mention "try another registered copy or recovered media"
     And stderr does not mention "20260420T040004Z-1"
 
-  @todo @issue_226
+  @todo @issue_301
   Scenario: arc-disc disc restore names the exact same-image disc after failed media
     Given statechart "arc_disc.hot_recovery" state "retry_other_disc" is the accepted operator contract
     And disc restore needs copy label "20260420T040003Z-1"
@@ -102,7 +102,7 @@ Feature: arc-disc CLI
     And stderr does not mention "try another registered disc or recovered media"
     And stderr does not mention "20260420T040004Z-1"
 
-  @todo @issue_226
+  @todo @issue_301
   Scenario: arc-disc failed media routes to recovery when same-image copies are exhausted
     Given statechart "arc_disc.fetch" state "recovery_workflow_needed" is the accepted operator contract
     And all registered same-image disc labels for fetch "fx-1" have failed

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -80,7 +80,6 @@ Feature: arc-disc CLI
       And the collection is not fully protected
 
   Rule: Targeted fetch detail remains available
-  @contract_gap @issue_317
   Scenario: arc-disc fetch names the exact same-image disc after rejected bytes
     Given statechart "arc_disc.fetch" state "retry_other_disc" is the accepted operator contract
     And fetch "fx-1" needs copy label "20260420T040003Z-1"
@@ -91,7 +90,6 @@ Feature: arc-disc CLI
     And stderr does not mention "try another registered copy or recovered media"
     And stderr does not mention "20260420T040004Z-1"
 
-  @contract_gap @issue_317
   Scenario: arc-disc disc restore names the exact same-image disc after failed media
     Given statechart "arc_disc.hot_recovery" state "retry_other_disc" is the accepted operator contract
     And disc restore needs copy label "20260420T040003Z-1"
@@ -102,7 +100,6 @@ Feature: arc-disc CLI
     And stderr does not mention "try another registered disc or recovered media"
     And stderr does not mention "20260420T040004Z-1"
 
-  @contract_gap @issue_317
   Scenario: arc-disc failed media routes to recovery when same-image copies are exhausted
     Given statechart "arc_disc.fetch" state "recovery_workflow_needed" is the accepted operator contract
     And all registered same-image disc labels for fetch "fx-1" have failed

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -80,6 +80,37 @@ Feature: arc-disc CLI
       And the collection is not fully protected
 
   Rule: Targeted fetch detail remains available
+  @todo @issue_226
+  Scenario: arc-disc fetch names the exact same-image disc after rejected bytes
+    Given statechart "arc_disc.fetch" state "retry_other_disc" is the accepted operator contract
+    And fetch "fx-1" needs copy label "20260420T040003Z-1"
+    And same-image copy label "20260420T040003Z-2" remains untried
+    When the server rejects recovered bytes from copy label "20260420T040003Z-1"
+    Then stderr includes operator copy "hot_recovery_retry_other_disc"
+    And stderr mentions "20260420T040003Z-2"
+    And stderr does not mention "try another registered copy or recovered media"
+    And stderr does not mention "20260420T040004Z-1"
+
+  @todo @issue_226
+  Scenario: arc-disc disc restore names the exact same-image disc after failed media
+    Given statechart "arc_disc.hot_recovery" state "retry_other_disc" is the accepted operator contract
+    And disc restore needs copy label "20260420T040003Z-1"
+    And same-image copy label "20260420T040003Z-2" remains untried
+    When copy label "20260420T040003Z-1" cannot restore the requested files
+    Then stderr includes operator copy "hot_recovery_retry_other_disc"
+    And stderr mentions "20260420T040003Z-2"
+    And stderr does not mention "try another registered disc or recovered media"
+    And stderr does not mention "20260420T040004Z-1"
+
+  @todo @issue_226
+  Scenario: arc-disc failed media routes to recovery when same-image copies are exhausted
+    Given statechart "arc_disc.fetch" state "recovery_workflow_needed" is the accepted operator contract
+    And all registered same-image disc labels for fetch "fx-1" have failed
+    When the operator runs 'arc-disc fetch "fx-1"'
+    Then stderr includes operator copy "hot_recovery_registered_copies_exhausted"
+    And stderr mentions "recovery workflow"
+    And stderr does not mention "try another registered copy"
+
   @ci_opt_in @requires_optical_disc_drive @requires_human_operator @issue_186 @issue_187
   Scenario: arc-disc fetch completes a recoverable fetch
     Given split archived target "docs/tax/2022/invoice-123.pdf" is pinned with fetch "fx-1"

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -544,6 +544,7 @@ class AcceptanceState:
     operator_blank_disc_work_available: bool = False
     operator_label_confirmation_location: str | None = None
     operator_collection_fully_protected: bool = False
+    operator_fetch_same_image_copies_exhausted: set[str] = field(default_factory=set)
 
     def clear_webhook_deliveries(self) -> None:
         with self.lock:
@@ -4405,6 +4406,56 @@ class AcceptanceSystem:
                 operator_copy.disc_item_hot_recovery_needs_media(target=target)
             )
 
+    def set_operator_fetch_same_image_copies_exhausted(self, fetch_id: str) -> None:
+        with self.state.lock:
+            self.state.operator_fetch_same_image_copies_exhausted.add(fetch_id)
+
+    def arc_disc_same_image_retry(
+        self,
+        *,
+        statechart: str,
+        target: str,
+        next_disc_label: str,
+    ) -> subprocess.CompletedProcess[str]:
+        stderr = operator_copy.hot_recovery_retry_other_disc(
+            target=target,
+            next_disc_label=next_disc_label,
+        )
+        return _operator_completed_process(
+            ["arc-disc"],
+            returncode=1,
+            stderr=stderr,
+            decisions=[_operator_decision(statechart, "retry_other_disc")],
+            views=[
+                _operator_view(
+                    statechart,
+                    "retry_other_disc",
+                    text=stderr,
+                )
+            ],
+        )
+
+    def arc_disc_registered_copies_exhausted(
+        self,
+        *,
+        fetch_id: str,
+        target: str,
+    ) -> subprocess.CompletedProcess[str]:
+        stderr = operator_copy.hot_recovery_registered_copies_exhausted(target=target)
+        return _operator_completed_process(
+            ["arc-disc", "fetch", fetch_id],
+            returncode=1,
+            stderr=stderr,
+            decisions=[_operator_decision("arc_disc.fetch", "recovery_workflow_needed")],
+            views=[
+                _operator_view(
+                    "arc_disc.fetch",
+                    "recovery_workflow_needed",
+                    text=stderr,
+                )
+            ],
+        )
+
     def set_operator_blank_disc_work_available(self) -> None:
         with self.state.lock:
             self.state.operator_blank_disc_work_available = True
@@ -4672,6 +4723,15 @@ class AcceptanceSystem:
     def run_arc_disc(
         self, *args: str, input_text: str = "\n" * 16
     ) -> subprocess.CompletedProcess[str]:
+        if len(args) >= 2 and args[0] == "fetch":
+            fetch_id = args[1]
+            with self.state.lock:
+                exhausted = fetch_id in self.state.operator_fetch_same_image_copies_exhausted
+            if exhausted:
+                return self.arc_disc_registered_copies_exhausted(
+                    fetch_id=fetch_id,
+                    target="docs/tax/2022/invoice-123.pdf",
+                )
         if not args:
             return self._arc_disc_contract_output()
         if not self.fixture_path.exists():

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -358,6 +358,15 @@ def _operator_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "hot_recovery_retry_other_disc":
+            return operator_copy.hot_recovery_retry_other_disc(
+                target="docs/tax/2022/invoice-123.pdf",
+                next_disc_label="20260420T040003Z-2",
+            )
+        case "hot_recovery_registered_copies_exhausted":
+            return operator_copy.hot_recovery_registered_copies_exhausted(
+                target="docs/tax/2022/invoice-123.pdf"
+            )
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
@@ -1154,6 +1163,68 @@ def given_pinned_files_need_recovery_from_disc(
         "fx-1",
     )
     acceptance_system.set_operator_hot_recovery_needs_media(INVOICE_TARGET)
+
+
+@given(parsers.parse('fetch "{fetch_id}" needs copy label "{copy_label}"'))
+def given_fetch_needs_copy_label(fetch_id: str, copy_label: str) -> None:
+    assert fetch_id == "fx-1"
+    assert copy_label == "20260420T040003Z-1"
+
+
+@given(parsers.parse('disc restore needs copy label "{copy_label}"'))
+def given_disc_restore_needs_copy_label(copy_label: str) -> None:
+    assert copy_label == "20260420T040003Z-1"
+
+
+@given(parsers.parse('same-image copy label "{copy_label}" remains untried'))
+def given_same_image_copy_label_remains_untried(copy_label: str) -> None:
+    assert copy_label == "20260420T040003Z-2"
+
+
+@given(parsers.parse('all registered same-image disc labels for fetch "{fetch_id}" have failed'))
+def given_all_same_image_disc_labels_have_failed(
+    acceptance_system: AcceptanceSystem,
+    fetch_id: str,
+) -> None:
+    acceptance_system.set_operator_fetch_same_image_copies_exhausted(fetch_id)
+
+
+@when(parsers.parse('the server rejects recovered bytes from copy label "{copy_label}"'))
+def when_server_rejects_recovered_bytes_from_copy_label(
+    acceptance_system: AcceptanceSystem,
+    acceptance_context: AcceptanceScenarioContext,
+    copy_label: str,
+) -> None:
+    assert copy_label == "20260420T040003Z-1"
+    acceptance_context.command_text = "arc-disc fetch fx-1"
+    acceptance_context.command_argv = ["arc-disc", "fetch", "fx-1"]
+    acceptance_context.stdout_json = None
+    acceptance_context.expected_api_endpoint = None
+    acceptance_context.expected_api_payload = None
+    acceptance_context.command = acceptance_system.arc_disc_same_image_retry(
+        statechart="arc_disc.fetch",
+        target=INVOICE_TARGET,
+        next_disc_label="20260420T040003Z-2",
+    )
+
+
+@when(parsers.parse('copy label "{copy_label}" cannot restore the requested files'))
+def when_copy_label_cannot_restore_requested_files(
+    acceptance_system: AcceptanceSystem,
+    acceptance_context: AcceptanceScenarioContext,
+    copy_label: str,
+) -> None:
+    assert copy_label == "20260420T040003Z-1"
+    acceptance_context.command_text = "arc-disc restore"
+    acceptance_context.command_argv = ["arc-disc", "restore"]
+    acceptance_context.stdout_json = None
+    acceptance_context.expected_api_endpoint = None
+    acceptance_context.expected_api_payload = None
+    acceptance_context.command = acceptance_system.arc_disc_same_image_retry(
+        statechart="arc_disc.hot_recovery",
+        target=INVOICE_TARGET,
+        next_disc_label="20260420T040003Z-2",
+    )
 
 
 @given(parsers.parse('the operator confirms labeled disc at storage location "{location}"'))

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -209,6 +209,30 @@ def _assert_actual_operator_view_matches_copy_ref(
     )
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _configured_optical_acceptance_device() -> str:
     return os.environ.get("ARC_DISC_ACCEPTANCE_DEVICE", _DEFAULT_OPTICAL_ACCEPTANCE_DEVICE)
 
@@ -4568,6 +4592,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4579,6 +4604,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4590,8 +4616,11 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    assert expected in _require_command(acceptance_context).stderr, _require_command(
+        acceptance_context
+    ).stderr
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
-    assert expected in _require_command(acceptance_context).stderr
 
 
 def _normalized_glacier_payload(payload: object) -> object:

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -59,6 +59,7 @@ from tests.fixtures.data import (
     DOCS_COLLECTION_ID,
     DOCS_FILES,
     IMAGE_FIXTURES,
+    INVOICE_TARGET,
     MIN_FILL_BYTES,
     PHOTOS_2024_FILES,
     SPLIT_COPY_ONE_ID,
@@ -1807,6 +1808,34 @@ class ProductionSystem:
         image = self.request("GET", f"/v1/images/{image_id}").json()
         staging_path = self.workspace / "arc_disc_staging" / image_id / str(image["filename"])
         return staging_path.is_file()
+
+    def _seed_same_image_recovery_fetch(self, fetch_id: str) -> None:
+        assert fetch_id == "fx-1"
+        self.seed_docs_archive_with_split_invoice()
+        response = self.request("POST", "/v1/pin", json_body={"target": INVOICE_TARGET})
+        assert response.status_code == 200, response.text
+        assert response.json()["fetch"]["id"] == fetch_id
+
+    def arc_disc_same_image_retry(
+        self,
+        *,
+        statechart: str,
+        target: str,
+        next_disc_label: str,
+    ) -> subprocess.CompletedProcess[str]:
+        assert statechart in {"arc_disc.fetch", "arc_disc.hot_recovery"}
+        assert target == INVOICE_TARGET
+        assert next_disc_label == "20260420T040003Z-2"
+        self._seed_same_image_recovery_fetch("fx-1")
+        return self.run_arc_disc(
+            "fetch",
+            "fx-1",
+            "--device",
+            str(self.workspace / "missing-optical-device"),
+        )
+
+    def set_operator_fetch_same_image_copies_exhausted(self, fetch_id: str) -> None:
+        self._seed_same_image_recovery_fetch(fetch_id)
 
     def pins_list(self) -> list[str]:
         return [item["target"] for item in self.request("GET", "/v1/pins").json()["pins"]]

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -1026,7 +1026,8 @@ class ProductionSystem:
 
     def _seed_image_copy(self, image_id: str, copy_id: str, location: str) -> None:
         with session_scope(make_session_factory(str(self.db_path))) as session:
-            if session.get(ImageCopyRecord, {"image_id": image_id, "copy_id": copy_id}) is not None:
+            existing = session.get(ImageCopyRecord, {"image_id": image_id, "copy_id": copy_id})
+            if existing is not None and existing.state in {"registered", "verified"}:
                 return
         self.copies.register(image_id, location, copy_id=copy_id)
 
@@ -1809,9 +1810,16 @@ class ProductionSystem:
         staging_path = self.workspace / "arc_disc_staging" / image_id / str(image["filename"])
         return staging_path.is_file()
 
-    def _seed_same_image_recovery_fetch(self, fetch_id: str) -> None:
+    def _seed_same_image_recovery_fetch(
+        self,
+        fetch_id: str,
+        *,
+        next_disc_label: str | None = None,
+    ) -> None:
         assert fetch_id == "fx-1"
         self.seed_docs_archive_with_split_invoice()
+        if next_disc_label is not None:
+            self._seed_image_copy("20260420T040003Z", next_disc_label, "vault-b/shelf-03")
         response = self.request("POST", "/v1/pin", json_body={"target": INVOICE_TARGET})
         assert response.status_code == 200, response.text
         assert response.json()["fetch"]["id"] == fetch_id
@@ -1826,7 +1834,7 @@ class ProductionSystem:
         assert statechart in {"arc_disc.fetch", "arc_disc.hot_recovery"}
         assert target == INVOICE_TARGET
         assert next_disc_label == "20260420T040003Z-2"
-        self._seed_same_image_recovery_fetch("fx-1")
+        self._seed_same_image_recovery_fetch("fx-1", next_disc_label=next_disc_label)
         return self.run_arc_disc(
             "fetch",
             "fx-1",

--- a/tests/unit/test_arc_disc.py
+++ b/tests/unit/test_arc_disc.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 import arc_disc.main as arc_disc_main
 from arc_core.domain.errors import HashMismatch
+from contracts.operator import copy as operator_copy
 from tests.fixtures.data import fixture_encrypt_bytes
 
 runner = CliRunner()
@@ -294,7 +295,12 @@ def test_arc_disc_fetch_resets_byte_complete_upload_after_final_verification_fai
     assert result.exit_code == 1
     assert cancelled == [("fx-1", "e1")]
     assert "reset byte-complete upload for tax/2022/invoice-123.pdf" in result.stderr
-    assert "try another registered copy or recovered media" in result.stderr
+    assert (
+        operator_copy.hot_recovery_registered_copies_exhausted(
+            target="docs/tax/2022/invoice-123.pdf"
+        )
+        in result.stderr
+    )
     assert "error: final fetch verification failed: sha256 did not match" in result.stderr
 
 
@@ -333,6 +339,12 @@ def test_arc_disc_fetch_reports_clean_error_when_optical_read_fails(monkeypatch)
     assert result.exit_code == 1
     assert (
         "error: fixture optical read failed for disc/000001.bin on /dev/fake-sr0" in result.stderr
+    )
+    assert (
+        operator_copy.hot_recovery_registered_copies_exhausted(
+            target="docs/tax/2022/invoice-123.pdf"
+        )
+        in result.stderr
     )
     assert "Traceback" not in result.stderr
 

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -205,6 +205,15 @@ def _feature_copy_text(name: str) -> str:
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
             return operator_copy.burn_label_checkpoint(label_text="20260420T040001Z-1")
+        case "hot_recovery_retry_other_disc":
+            return operator_copy.hot_recovery_retry_other_disc(
+                target="docs/tax/2022/invoice-123.pdf",
+                next_disc_label="20260420T040003Z-2",
+            )
+        case "hot_recovery_registered_copies_exhausted":
+            return operator_copy.hot_recovery_registered_copies_exhausted(
+                target="docs/tax/2022/invoice-123.pdf",
+            )
     raise AssertionError(f"unsupported operator copy reference: {name}")
 
 

--- a/tests/unit/test_operator_statecharts.py
+++ b/tests/unit/test_operator_statecharts.py
@@ -369,11 +369,11 @@ def test_mermaid_generator_writes_clear_compatible_mmdc_validated_workflows(
         in hot_recovery
     )
     assert (
-        'operator_inserts_another_disc_retry_other_disc_insert_disc_1'
-        '(["<b>Operator Inserts Another Disc</b>"]):::eventNode'
+        'operator_inserts_named_disc_retry_other_disc_insert_disc_1'
+        '(["<b>Operator Inserts Named Disc</b>"]):::eventNode'
     ) in hot_recovery
     assert "guard_restore_complete" not in hot_recovery
-    assert "event_operator_inserts_another_disc" not in hot_recovery
+    assert "event_operator_inserts_named_disc" not in hot_recovery
     assert (
         'link_pin_waiting_for_disc_to_arc_disc_guided_scan_backlog'
         '[["<b>Operator Runs Arc Disc</b>"]]:::linkNode'


### PR DESCRIPTION
## Summary
- model exact same-image retry labels and exhausted-copy recovery handoff for fetch/disc restore
- document the accepted retry behavior
- back fetch retry, disc-restore retry, and exhausted-copy recovery routing in the spec and prod harnesses
- implement production retry routing so failed media/rejected bytes name exact same-image labels or route to recovery
- remove the resolved Dev #317 contract-gap markers

## Tracking
- PM child #226 is closed
- Test child #301 is closed
- Test child #318 is closed
- Dev child #317 is closed

## Verification
- make lint
- make unit args='tests/unit/test_acceptance_marker_enforcement.py'
- make unit args='tests/unit/test_arc_disc.py -k "fetch"'
- make spec args='-k "test_arcdisc_fetch_names_the_exact_sameimage_disc_after_rejected_bytes or test_arcdisc_disc_restore_names_the_exact_sameimage_disc_after_failed_media or test_arcdisc_failed_media_routes_to_recovery_when_sameimage_copies_are_exhausted"'
- make prod args='-k "test_arcdisc_fetch_names_the_exact_sameimage_disc_after_rejected_bytes or test_arcdisc_disc_restore_names_the_exact_sameimage_disc_after_failed_media or test_arcdisc_failed_media_routes_to_recovery_when_sameimage_copies_are_exhausted" -vv --showlocals'
