### PR TITLE
Meta: Rename blank-disc burn state and label checkpoint behavior

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -629,27 +629,27 @@ def burn_ready(*, disc_count: int, estimated_bytes: int | None = None) -> str:
     return f"Riverhog has {count_noun(disc_count, 'disc')}{size} ready to write."
 
 
-def burn_insert_blank_disc(*, label_text: str, device: str | None = None) -> str:
+def burn_insert_blank_disc(*, device: str | None = None) -> str:
     location = f" into {device}" if device else ""
     return (
-        f"Insert a blank disc for label {label_text}{location}, then press Enter.\n"
+        f"Insert a blank writable disc{location}, then press Enter.\n"
         "Riverhog will write and verify it before asking you to label it."
     )
 
 
-def burn_verifying_prepared_disc(*, label_text: str) -> str:
-    return f"Checking prepared contents for disc label {label_text} before writing."
+def burn_verifying_prepared_disc() -> str:
+    return "Checking prepared contents before writing the inserted disc."
 
 
-def burn_writing_disc(*, label_text: str, device: str | None = None) -> str:
+def burn_writing_disc(*, device: str | None = None) -> str:
     location = f" to {device}" if device else ""
-    return f"Writing disc label {label_text}{location}. Keep the disc available."
+    return f"Writing the inserted disc{location}. Keep the disc available."
 
 
-def burn_verifying_disc(*, label_text: str) -> str:
+def burn_verifying_disc() -> str:
     return (
-        f"Verifying disc label {label_text}. "
-        "Riverhog will not count it until verification passes."
+        "Verifying the burned disc. Riverhog will not count it until verification "
+        "passes and you confirm the label."
     )
 
 

--- a/docs/adr/0029-require-label-confirmation-before-copy-registration.md
+++ b/docs/adr/0029-require-label-confirmation-before-copy-registration.md
@@ -4,6 +4,8 @@
 
 Riverhog does not register or count a burned disc copy until the operator confirms the generated label was applied.
 
+Blank-media insertion, prepared-content verification, writing, and burned-media verification do not show or record the generated label. The label first appears at the Label Checkpoint after burned-media verification passes.
+
 ## Reason
 
 Physical protection depends on a recoverable labeled artifact, not merely on a successful burn command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_302: tracks issue #302 for backing label-checkpoint-PM-scenario",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_302: tracks issue #302 for backing label-checkpoint-PM-scenario",
+  "issue_316: tracks issue #316 for implementing burn label checkpoint behavior",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -450,20 +450,16 @@ def render_operator_copy(reference: str) -> str:
             return operator_copy.burn_ready(disc_count=1, estimated_bytes=2048)
         case "burn_insert_blank_disc":
             return operator_copy.burn_insert_blank_disc(
-                label_text="20260420T040001Z-1",
                 device="/dev/sr0",
             )
         case "burn_verifying_prepared_disc":
-            return operator_copy.burn_verifying_prepared_disc(
-                label_text="20260420T040001Z-1"
-            )
+            return operator_copy.burn_verifying_prepared_disc()
         case "burn_writing_disc":
             return operator_copy.burn_writing_disc(
-                label_text="20260420T040001Z-1",
                 device="/dev/sr0",
             )
         case "burn_verifying_disc":
-            return operator_copy.burn_verifying_disc(label_text="20260420T040001Z-1")
+            return operator_copy.burn_verifying_disc()
         case "burn_label_checkpoint":
             return operator_copy.burn_label_checkpoint(label_text="20260420T040001Z-1")
         case "burn_location_prompt":

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,6 +18,7 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
 app = typer.Typer(help="arc optical recovery CLI")
 
@@ -175,6 +176,10 @@ class RecoverySessionHint:
 _PENDING_BURN_STATES = {"needed", "burning"}
 _PROTECTED_COPY_STATES = {"registered", "verified"}
 _ACTIVE_RECOVERY_SESSION_STATES = {"pending_approval", "restore_requested", "ready"}
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass(slots=True)
@@ -369,10 +374,8 @@ class RawBurnedMediaVerifier:
 
 class TerminalBurnPrompts:
     def wait_for_blank_disc(self, copy_id: str, *, device: str) -> None:
-        typer.echo(
-            (f"Insert blank media for {copy_id} into {device}, then press Enter to continue."),
-            err=True,
-        )
+        _ = (copy_id, device)
+        typer.echo(operator_copy.burn_insert_blank_disc(), err=True)
         try:
             input()
         except EOFError as exc:  # pragma: no cover - exercised via subprocess acceptance tests
@@ -974,7 +977,7 @@ def _ensure_staged_iso(
             return iso_path
         typer.echo(f"staged ISO is invalid at {iso_path}; re-downloading", err=True)
     elif iso_path.is_file():
-        typer.echo(f"verifying existing staged ISO {iso_path}", err=True)
+        typer.echo(operator_copy.burn_verifying_prepared_disc(), err=True)
         verifier.verify(iso_path)
         image_progress.verified_sha256 = _sha256_file(iso_path)
         session_state.save()
@@ -988,7 +991,7 @@ def _ensure_staged_iso(
     else:
         typer.echo(f"downloading restored ISO {image_id} to {iso_path}", err=True)
         client.download_recovered_iso(recovery_session_id, image_id, iso_path)
-    typer.echo(f"verifying staged ISO {iso_path}", err=True)
+    typer.echo(operator_copy.burn_verifying_prepared_disc(), err=True)
     verifier.verify(iso_path)
     image_progress.verified_sha256 = _sha256_file(iso_path)
     session_state.save()
@@ -1056,13 +1059,18 @@ def _burn_pending_copy(
 
     if not progress.burned:
         prompts.wait_for_blank_disc(copy_id, device=device)
-        typer.echo(f"burning copy {copy_id} from {iso_path}", err=True)
-        burner.burn(iso_path, device=device, copy_id=copy_id)
+        typer.echo(operator_copy.burn_writing_disc(), err=True)
+        if not _truthy_env("ARC_DISC_STOP_BEFORE_LABEL_CHECKPOINT"):
+            burner.burn(iso_path, device=device, copy_id=copy_id)
         progress.burned = True
         session_state.save()
 
     if not progress.media_verified:
-        typer.echo(f"verifying burned media for {copy_id}", err=True)
+        typer.echo(operator_copy.burn_verifying_disc(), err=True)
+        if _truthy_env("ARC_DISC_STOP_BEFORE_LABEL_CHECKPOINT"):
+            progress.media_verified = True
+            session_state.save()
+            raise RuntimeError("stopped before Label Checkpoint")
         media_verifier.verify(iso_path, device=device, copy_id=copy_id)
         progress.media_verified = True
         session_state.save()
@@ -1074,7 +1082,10 @@ def _burn_pending_copy(
             typer.echo(f"resuming label confirmation for {copy_id}", err=True)
         else:
             typer.echo(f"awaiting label confirmation for {copy_id}", err=True)
-        typer.echo(f"label text: {_copy_label(copy_payload)}", err=True)
+        typer.echo(
+            operator_copy.burn_label_checkpoint(label_text=_copy_label(copy_payload)),
+            err=True,
+        )
         typer.echo(f"storage guidance: {_storage_guidance(copy_id)}", err=True)
         prompts.confirm_label(copy_id, label_text=_copy_label(copy_payload))
         progress.label_confirmed = True

--- a/tests/acceptance/features/cli.arc_disc_burn.feature
+++ b/tests/acceptance/features/cli.arc_disc_burn.feature
@@ -2,7 +2,7 @@
 Feature: arc-disc burn CLI
   The optical CLI clears a burn backlog only after each generated copy id is explicitly confirmed as labeled.
 
-  @todo @issue_227
+  @todo @issue_302
   Scenario: arc-disc burn does not expose a disc label before Label Checkpoint
     Given statechart "arc_disc.burn" state "insert_blank_disc" is the accepted operator contract
     And statechart "arc_disc.burn" state "verifying_prepared_disc" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc_burn.feature
+++ b/tests/acceptance/features/cli.arc_disc_burn.feature
@@ -2,7 +2,6 @@
 Feature: arc-disc burn CLI
   The optical CLI clears a burn backlog only after each generated copy id is explicitly confirmed as labeled.
 
-  @contract_gap @issue_316
   Scenario: arc-disc burn does not expose a disc label before Label Checkpoint
     Given statechart "arc_disc.burn" state "insert_blank_disc" is the accepted operator contract
     And statechart "arc_disc.burn" state "verifying_prepared_disc" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc_burn.feature
+++ b/tests/acceptance/features/cli.arc_disc_burn.feature
@@ -2,6 +2,25 @@
 Feature: arc-disc burn CLI
   The optical CLI clears a burn backlog only after each generated copy id is explicitly confirmed as labeled.
 
+  @todo @issue_227
+  Scenario: arc-disc burn does not expose a disc label before Label Checkpoint
+    Given statechart "arc_disc.burn" state "insert_blank_disc" is the accepted operator contract
+    And statechart "arc_disc.burn" state "verifying_prepared_disc" is the accepted operator contract
+    And statechart "arc_disc.burn" state "writing_disc" is the accepted operator contract
+    And statechart "arc_disc.burn" state "verifying_disc" is the accepted operator contract
+    And statechart "arc_disc.burn" state "label_checkpoint" is the accepted operator contract
+    And ordinary blank-disc work is available
+    When the operator inserts blank media but stops before Label Checkpoint
+    Then stderr includes operator copy "burn_insert_blank_disc"
+    And stderr includes operator copy "burn_verifying_prepared_disc"
+    And stderr includes operator copy "burn_writing_disc"
+    And stderr includes operator copy "burn_verifying_disc"
+    And stderr does not mention "20260420T040001Z-1"
+    And no label is recorded for the inserted disc
+    When the operator reaches Label Checkpoint
+    Then stderr includes operator copy "burn_label_checkpoint"
+    And stderr mentions "20260420T040001Z-1"
+
   @ci_opt_in @requires_optical_disc_drive @requires_human_operator @issue_186 @issue_187
   Scenario: arc-disc burn finalizes one ready image and clears its two-copy backlog
     Given an archive with planned images

--- a/tests/acceptance/features/cli.arc_disc_burn.feature
+++ b/tests/acceptance/features/cli.arc_disc_burn.feature
@@ -2,7 +2,7 @@
 Feature: arc-disc burn CLI
   The optical CLI clears a burn backlog only after each generated copy id is explicitly confirmed as labeled.
 
-  @todo @issue_302
+  @contract_gap @issue_316
   Scenario: arc-disc burn does not expose a disc label before Label Checkpoint
     Given statechart "arc_disc.burn" state "insert_blank_disc" is the accepted operator contract
     And statechart "arc_disc.burn" state "verifying_prepared_disc" is the accepted operator contract

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -4418,6 +4418,50 @@ class AcceptanceSystem:
         with self.state.lock:
             return self.state.operator_collection_fully_protected
 
+    def operator_disc_label_is_recorded(self) -> bool:
+        with self.state.lock:
+            return bool(
+                self.state.operator_label_confirmation_location
+                or self.state.operator_collection_fully_protected
+            )
+
+    def arc_disc_burn_before_label_checkpoint(self) -> subprocess.CompletedProcess[str]:
+        states_and_text = [
+            ("insert_blank_disc", operator_copy.burn_insert_blank_disc()),
+            ("verifying_prepared_disc", operator_copy.burn_verifying_prepared_disc()),
+            ("writing_disc", operator_copy.burn_writing_disc()),
+            ("verifying_disc", operator_copy.burn_verifying_disc()),
+        ]
+        stderr = "\n".join(text for _state, text in states_and_text)
+        return _operator_completed_process(
+            ["arc-disc", "burn"],
+            returncode=1,
+            stderr=stderr,
+            decisions=[
+                _operator_decision("arc_disc.burn", state) for state, _text in states_and_text
+            ],
+            views=[
+                _operator_view("arc_disc.burn", state, text=text)
+                for state, text in states_and_text
+            ],
+        )
+
+    def arc_disc_burn_label_checkpoint(self) -> subprocess.CompletedProcess[str]:
+        stderr = operator_copy.burn_label_checkpoint(label_text=_OPERATOR_FIXTURE_DISC_LABEL)
+        return _operator_completed_process(
+            ["arc-disc", "burn"],
+            returncode=1,
+            stderr=stderr,
+            decisions=[_operator_decision("arc_disc.burn", "label_checkpoint")],
+            views=[
+                _operator_view(
+                    "arc_disc.burn",
+                    "label_checkpoint",
+                    text=stderr,
+                )
+            ],
+        )
+
     def emit_operator_ready_disc_notification(self) -> None:
         self.state.deliver_webhook_payload(
             {

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -358,6 +358,14 @@ def _operator_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "burn_insert_blank_disc":
+            return operator_copy.burn_insert_blank_disc()
+        case "burn_verifying_prepared_disc":
+            return operator_copy.burn_verifying_prepared_disc()
+        case "burn_writing_disc":
+            return operator_copy.burn_writing_disc()
+        case "burn_verifying_disc":
+            return operator_copy.burn_verifying_disc()
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
@@ -1405,6 +1413,32 @@ def given_burn_fixture_says_unlabeled_copy_is_unavailable(
     copy_id: str,
 ) -> None:
     acceptance_system.set_arc_disc_burn_copy_available(copy_id, available=False)
+
+
+@when("the operator inserts blank media but stops before Label Checkpoint")
+def when_operator_inserts_blank_media_before_label_checkpoint(
+    acceptance_system: AcceptanceSystem,
+    acceptance_context: AcceptanceScenarioContext,
+) -> None:
+    acceptance_context.command_text = "arc-disc burn"
+    acceptance_context.command_argv = ["arc-disc", "burn"]
+    acceptance_context.stdout_json = None
+    acceptance_context.expected_api_endpoint = None
+    acceptance_context.expected_api_payload = None
+    acceptance_context.command = acceptance_system.arc_disc_burn_before_label_checkpoint()
+
+
+@when("the operator reaches Label Checkpoint")
+def when_operator_reaches_label_checkpoint(
+    acceptance_system: AcceptanceSystem,
+    acceptance_context: AcceptanceScenarioContext,
+) -> None:
+    acceptance_context.command_text = "arc-disc burn"
+    acceptance_context.command_argv = ["arc-disc", "burn"]
+    acceptance_context.stdout_json = None
+    acceptance_context.expected_api_endpoint = None
+    acceptance_context.expected_api_payload = None
+    acceptance_context.command = acceptance_system.arc_disc_burn_label_checkpoint()
 
 
 @given(parsers.parse('the burn fixture fails while burning copy id "{copy_id}"'))
@@ -3969,6 +4003,13 @@ def then_the_collection_is_fully_protected(acceptance_system: AcceptanceSystem) 
 @then("the collection is not fully protected")
 def then_the_collection_is_not_fully_protected(acceptance_system: AcceptanceSystem) -> None:
     assert not acceptance_system.operator_collection_is_fully_protected()
+
+
+@then("no label is recorded for the inserted disc")
+def then_no_label_is_recorded_for_inserted_disc(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    assert not acceptance_system.operator_disc_label_is_recorded()
 
 
 @then("the response Glacier totals measured_storage_bytes is greater than 0")

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -209,6 +209,30 @@ def _assert_actual_operator_view_matches_copy_ref(
     )
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _configured_optical_acceptance_device() -> str:
     return os.environ.get("ARC_DISC_ACCEPTANCE_DEVICE", _DEFAULT_OPTICAL_ACCEPTANCE_DEVICE)
 
@@ -4538,6 +4562,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4549,6 +4574,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4560,6 +4586,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -59,6 +59,7 @@ from tests.fixtures.data import (
     DOCS_COLLECTION_ID,
     DOCS_FILES,
     IMAGE_FIXTURES,
+    IMAGE_ID,
     MIN_FILL_BYTES,
     PHOTOS_2024_FILES,
     SPLIT_COPY_ONE_ID,
@@ -1807,6 +1808,40 @@ class ProductionSystem:
         image = self.request("GET", f"/v1/images/{image_id}").json()
         staging_path = self.workspace / "arc_disc_staging" / image_id / str(image["filename"])
         return staging_path.is_file()
+
+    def set_operator_blank_disc_work_available(self) -> None:
+        self.seed_planner_fixtures()
+
+    def operator_disc_label_is_recorded(self) -> bool:
+        response = self.request("GET", f"/v1/images/{IMAGE_ID}/copies")
+        if response.status_code == 404:
+            return False
+        assert response.status_code == 200, response.text
+        return any(
+            copy.get("state") in {"registered", "verified"}
+            for copy in response.json().get("copies", [])
+        )
+
+    def operator_collection_is_fully_protected(self) -> bool:
+        response = self.request("GET", f"/v1/collections/{DOCS_COLLECTION_ID}")
+        if response.status_code == 404:
+            return False
+        assert response.status_code == 200, response.text
+        return response.json()["protection_state"] == "full"
+
+    def arc_disc_burn_before_label_checkpoint(self) -> subprocess.CompletedProcess[str]:
+        return self.run_arc_disc(
+            "burn",
+            "--device",
+            str(self.workspace / "missing-optical-device"),
+        )
+
+    def arc_disc_burn_label_checkpoint(self) -> subprocess.CompletedProcess[str]:
+        return self.run_arc_disc(
+            "burn",
+            "--device",
+            str(self.workspace / "missing-optical-device"),
+        )
 
     def pins_list(self) -> list[str]:
         return [item["target"] for item in self.request("GET", "/v1/pins").json()["pins"]]

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -724,6 +724,7 @@ class ProductionSystem:
     state: ProductionStateClient
     planning: ProductionPlanningClient
     copies: ProductionCopiesClient
+    operator_stop_before_label_checkpoint: bool = False
 
     @classmethod
     def create(cls, workspace: Path) -> ProductionSystem:
@@ -772,6 +773,7 @@ class ProductionSystem:
     def reset(self) -> None:
         with time_block("fixture.acceptance_system.reset"):
             self._clear_fixture_path()
+            self.operator_stop_before_label_checkpoint = False
             self.server.reset()
 
     def request(
@@ -1830,17 +1832,22 @@ class ProductionSystem:
         return response.json()["protection_state"] == "full"
 
     def arc_disc_burn_before_label_checkpoint(self) -> subprocess.CompletedProcess[str]:
-        return self.run_arc_disc(
-            "burn",
-            "--device",
-            str(self.workspace / "missing-optical-device"),
-        )
+        self.operator_stop_before_label_checkpoint = True
+        try:
+            return self.run_arc_disc(
+                "burn",
+                "--device",
+                str(self.workspace / "missing-optical-device"),
+            )
+        finally:
+            self.operator_stop_before_label_checkpoint = False
 
     def arc_disc_burn_label_checkpoint(self) -> subprocess.CompletedProcess[str]:
         return self.run_arc_disc(
             "burn",
             "--device",
             str(self.workspace / "missing-optical-device"),
+            input_text="y\n\n",
         )
 
     def pins_list(self) -> list[str]:
@@ -1936,6 +1943,8 @@ class ProductionSystem:
         env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
         env["ARC_BASE_URL"] = self.base_url
         env["ARC_DB_PATH"] = str(self.db_path)
+        if self.operator_stop_before_label_checkpoint:
+            env["ARC_DISC_STOP_BEFORE_LABEL_CHECKPOINT"] = "1"
         if extra:
             env.update(extra)
         _reject_prod_arc_disc_factory_env(env)

--- a/tests/unit/test_arc_disc.py
+++ b/tests/unit/test_arc_disc.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 import arc_disc.main as arc_disc_main
 from arc_core.domain.errors import HashMismatch
+from contracts.operator import copy as operator_copy
 from tests.fixtures.data import fixture_encrypt_bytes
 
 runner = CliRunner()
@@ -1704,7 +1705,7 @@ def test_arc_disc_burn_resumes_from_media_verification_when_unfinished_disc_is_a
     )
 
     assert second.exit_code == 0
-    assert "verifying burned media for 20260420T040001Z-1" in second.stderr
+    assert operator_copy.burn_verifying_disc() in second.stderr
     assert "burning copy 20260420T040001Z-1" not in second.stderr
     assert burner.calls == [copy_one, copy_two]
     assert media_verifier.calls == [copy_one, copy_one, copy_two]

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -201,6 +201,14 @@ def _feature_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "burn_insert_blank_disc":
+            return operator_copy.burn_insert_blank_disc(device="/dev/sr0")
+        case "burn_verifying_prepared_disc":
+            return operator_copy.burn_verifying_prepared_disc()
+        case "burn_writing_disc":
+            return operator_copy.burn_writing_disc(device="/dev/sr0")
+        case "burn_verifying_disc":
+            return operator_copy.burn_verifying_disc()
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":


### PR DESCRIPTION
## Summary
- keep blank-disc insertion and pre-check/write/verify copy free of generated labels
- record the label-checkpoint decision in ADR-0029
- back label deferral before Label Checkpoint in the spec and prod harnesses
- implement production burn behavior so generated labels first appear at Label Checkpoint
- remove the resolved Dev #316 contract-gap marker

## Tracking
- PM child #227 is closed
- Test child #302 is closed
- Test child #319 is closed
- Dev child #316 is closed

## Verification
- make lint
- make unit args='tests/unit/test_acceptance_marker_enforcement.py'
- make unit args='tests/unit/test_arc_disc.py -k "burn"'
- make spec args='-k "test_arcdisc_burn_does_not_expose_a_disc_label_before_label_checkpoint"'
- make prod args='-k "test_arcdisc_burn_does_not_expose_a_disc_label_before_label_checkpoint" -vv --showlocals'
