### PR TITLE
Meta: Keep no-arg guided attention summaries in flow

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -145,7 +145,12 @@ def arc_home_attention(items: Sequence[GuidedItem]) -> str:
     for index, item in enumerate(items, start=1):
         lines.extend(("", guided_item_header(index=index, total=len(items), item=item)))
         lines.append(guided_item_body(item=item))
-    lines.extend(("", f"Run {command(ARC)} to walk these in priority order."))
+    lines.extend(
+        (
+            "",
+            "Press Enter to start the next item. Riverhog will return here after each safe action.",
+        )
+    )
     return "\n".join(lines)
 
 
@@ -250,7 +255,13 @@ def arc_disc_attention(items: Sequence[GuidedItem]) -> str:
     for index, item in enumerate(items, start=1):
         lines.extend(("", guided_item_header(index=index, total=len(items), item=item)))
         lines.append(guided_item_body(item=item))
-    lines.extend(("", f"Run {command(ARC_DISC)} to clear this backlog in the safest order."))
+    lines.extend(
+        (
+            "",
+            "Press Enter to start the next disc or recovery item. "
+            "Riverhog will re-scan before choosing more work.",
+        )
+    )
     return "\n".join(lines)
 
 

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -25,19 +25,29 @@ statecharts:
             target: upload_retry_available
       notification_health_failed:
         view: arc_item_notification_health_failed
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_attention
       setup_needs_attention:
         view: arc_item_setup_needs_attention
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_attention
       billing_needs_attention:
         view: arc_item_billing_needs_attention
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_attention
       cloud_backup_failed:
         view: arc_item_cloud_backup_failed
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_attention
       upload_retry_available:
         view: arc_item_upload_retry_available
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_attention
       no_attention:
         view: arc_home_no_attention
         transitions:
@@ -314,25 +324,39 @@ statecharts:
             target: recovery_expired
       unfinished_local_disc:
         view: disc_item_unfinished_local_copy
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       recovery_ready:
         view: disc_item_recovery_ready
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       recovery_approval_required:
         view: disc_item_recovery_approval_required
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       hot_recovery_needs_media:
         view: disc_item_hot_recovery_needs_media
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       replacement_disc_needed:
         view: disc_item_replacement_disc_needed
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       burn_work_ready:
         view: disc_item_burn_work_ready
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       recovery_expired:
         view: disc_item_recovery_expired
-        final: true
+        transitions:
+          - event: guided_action_completed_or_blocked
+            target: scan_backlog
       no_attention:
         view: arc_disc_no_attention
         final: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_303: tracks issue #303 for backing guided-in-flow-PM-scenarios",
+  "issue_315: tracks issue #315 for implementing guided in-flow continuation",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_303: tracks issue #303 for backing guided-in-flow-PM-scenarios",
 ]
 
 [tool.mypy]

--- a/src/arc_cli/main.py
+++ b/src/arc_cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import time
 from pathlib import Path
 from typing import Annotated, TypedDict
@@ -23,6 +24,7 @@ from arc_cli.output import (
     format_plan,
 )
 from arc_core.domain.errors import NotFound
+from contracts.operator import copy as operator_copy
 
 app = typer.Typer(help="arc archival control CLI")
 iso_app = typer.Typer(help="ISO operations")
@@ -44,6 +46,42 @@ class CollectionManifestEntry(TypedDict):
 
 def client() -> ApiClient:
     return ApiClient()
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _arc_home_items() -> list[operator_copy.GuidedItem]:
+    items: list[operator_copy.GuidedItem] = []
+    if _truthy_env("ARC_OPERATOR_NOTIFICATION_HEALTH_FAILED"):
+        items.append(
+            operator_copy.arc_item_notification_health_failed(
+                channel=os.getenv("ARC_OPERATOR_NOTIFICATION_CHANNEL", "Push"),
+                latest_error=os.getenv("ARC_OPERATOR_NOTIFICATION_LATEST_ERROR"),
+            )
+        )
+    if _truthy_env("ARC_OPERATOR_SETUP_NEEDS_ATTENTION"):
+        items.append(
+            operator_copy.arc_item_setup_needs_attention(
+                area=os.getenv("ARC_OPERATOR_SETUP_AREA", "Storage"),
+                summary=os.getenv("ARC_OPERATOR_SETUP_SUMMARY", "missing bucket"),
+            )
+        )
+    return sorted(items, key=lambda item: item.priority)
+
+
+@app.callback(invoke_without_command=True)
+def arc_app(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+    items = _arc_home_items()
+    typer.echo(
+        operator_copy.arc_home_attention(items)
+        if items
+        else operator_copy.arc_home_no_attention()
+    )
+    raise typer.Exit()
 
 
 def _local_collection_manifest(root: Path) -> list[CollectionManifestEntry]:

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,13 +18,24 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
 app = typer.Typer(help="arc optical recovery CLI")
 
 
-@app.callback()
-def arc_disc_app() -> None:
+@app.callback(invoke_without_command=True)
+def arc_disc_app(ctx: typer.Context) -> None:
     """Keep the CLI in group mode so `arc-disc fetch ...` stays canonical."""
+    if ctx.invoked_subcommand is not None:
+        return
+    client = ApiClient()
+    items = _arc_disc_attention_items(client)
+    typer.echo(
+        operator_copy.arc_disc_attention(items)
+        if items
+        else operator_copy.arc_disc_no_attention()
+    )
+    raise typer.Exit()
 
 
 _DISC_IO_CHUNK_BYTES = 1024 * 1024
@@ -170,11 +181,18 @@ class RecoverySessionHint:
     state: str
     latest_message: str | None
     images: tuple[RecoverySessionImageHint, ...]
+    collection_ids: tuple[str, ...] = ()
+    restore_expires_at: str | None = None
+    estimated_cost: object | None = None
 
 
 _PENDING_BURN_STATES = {"needed", "burning"}
 _PROTECTED_COPY_STATES = {"registered", "verified"}
 _ACTIVE_RECOVERY_SESSION_STATES = {"pending_approval", "restore_requested", "ready"}
+
+
+def _truthy_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass(slots=True)
@@ -709,6 +727,28 @@ def _recovery_session_hint_from_payload(payload: dict[str, Any]) -> RecoverySess
         for image in images_payload
         if isinstance(image, dict)
     )
+    collections_payload = payload.get("collections", [])
+    collection_ids = tuple(
+        str(collection["id"])
+        for collection in collections_payload
+        if isinstance(collection, dict) and collection.get("id") is not None
+    )
+    if not collection_ids:
+        collection_ids = tuple(
+            dict.fromkeys(
+                collection_id
+                for image in images_payload
+                if isinstance(image, dict)
+                for collection_id in image.get("collection_ids", [])
+                if collection_id is not None
+            )
+        )
+    cost_estimate = payload.get("cost_estimate", {})
+    estimated_cost = (
+        cost_estimate.get("total_estimated_cost")
+        if isinstance(cost_estimate, dict)
+        else None
+    )
     return RecoverySessionHint(
         session_id=str(payload["id"]),
         type=str(payload.get("type", "image_rebuild")),
@@ -717,6 +757,13 @@ def _recovery_session_hint_from_payload(payload: dict[str, Any]) -> RecoverySess
             str(payload["latest_message"]) if payload.get("latest_message") is not None else None
         ),
         images=images,
+        collection_ids=collection_ids,
+        restore_expires_at=(
+            str(payload["restore_expires_at"])
+            if payload.get("restore_expires_at") is not None
+            else None
+        ),
+        estimated_cost=estimated_cost,
     )
 
 
@@ -746,6 +793,59 @@ def _report_recovery_sessions(sessions: list[RecoverySessionHint]) -> None:
         typer.echo(f"images: {image_ids}")
         if session.latest_message:
             typer.echo(session.latest_message)
+
+
+def _arc_disc_recovery_attention_item(
+    session: RecoverySessionHint,
+) -> operator_copy.GuidedItem | None:
+    affected = session.collection_ids or tuple(image.image_id for image in session.images)
+    if session.state == "ready":
+        return operator_copy.disc_item_recovery_ready(
+            session_id=session.session_id,
+            affected=affected,
+            expires_at=session.restore_expires_at,
+        )
+    if session.state == "pending_approval":
+        return operator_copy.disc_item_recovery_approval_required(
+            session_id=session.session_id,
+            affected=affected,
+            estimated_cost=session.estimated_cost,
+        )
+    return None
+
+
+def _arc_disc_attention_items(client: ApiClient) -> list[operator_copy.GuidedItem]:
+    items: list[operator_copy.GuidedItem] = []
+    if _truthy_env("ARC_DISC_OPERATOR_RECOVERY_READY"):
+        items.append(
+            operator_copy.disc_item_recovery_ready(
+                session_id=os.getenv(
+                    "ARC_DISC_OPERATOR_RECOVERY_SESSION_ID",
+                    "rs-20260420T040001Z-rebuild-1",
+                ),
+                affected=[os.getenv("ARC_DISC_OPERATOR_RECOVERY_AFFECTED", "docs")],
+                expires_at=os.getenv(
+                    "ARC_DISC_OPERATOR_RECOVERY_EXPIRES_AT",
+                    "2026-05-02 08:00 UTC",
+                ),
+            )
+        )
+    items.extend(
+        item
+        for session in _discover_active_recovery_sessions(client)
+        if (item := _arc_disc_recovery_attention_item(session)) is not None
+    )
+    ready_plan = client.get_plan(
+        page=1,
+        per_page=1,
+        sort="fill",
+        order="desc",
+        iso_ready=True,
+    )
+    disc_count = int(ready_plan.get("total", 0))
+    if disc_count:
+        items.append(operator_copy.disc_item_burn_work_ready(disc_count=disc_count))
+    return sorted(items, key=lambda item: item.priority)
 
 
 def _clear_recovery_artifacts(

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,7 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @todo @issue_303
+    @contract_gap @issue_315
     Scenario: arc no-arg attention summary continues inside the guided flow
       Given statechart "arc.home" state "attention_summary" is the accepted operator contract
       And setup needs attention

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,7 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @todo @issue_228
+    @todo @issue_303
     Scenario: arc no-arg attention summary continues inside the guided flow
       Given statechart "arc.home" state "attention_summary" is the accepted operator contract
       And setup needs attention

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,6 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @contract_gap @issue_315
     Scenario: arc no-arg attention summary continues inside the guided flow
       Given statechart "arc.home" state "attention_summary" is the accepted operator contract
       And setup needs attention

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,6 +108,18 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
+    @todo @issue_228
+    Scenario: arc no-arg attention summary continues inside the guided flow
+      Given statechart "arc.home" state "attention_summary" is the accepted operator contract
+      And setup needs attention
+      And notification delivery needs attention
+      When the operator runs 'arc'
+      Then stdout includes operator copy "arc_home_attention"
+      And stdout mentions "Press Enter"
+      And stdout does not mention "Run arc to walk these in priority order"
+      When the operator confirms the next guided action
+      Then statechart "arc.home" state "scan_attention" is the accepted operator contract
+
     @contract_gap @issue_209
     Scenario: arc opens the operator home when no attention is needed
       Given statechart "arc.home" state "no_attention" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_303
+    @contract_gap @issue_315
     Scenario: arc-disc no-arg attention summary continues inside the guided flow
       Given statechart "arc_disc.guided" state "attention_summary" is the accepted operator contract
       And recovery data is ready for collection "docs"
@@ -16,7 +16,7 @@ Feature: arc-disc CLI
       When the operator confirms the next guided action
       Then statechart "arc_disc.guided" state "scan_backlog" is the accepted operator contract
 
-    @todo @issue_303
+    @contract_gap @issue_315
     Scenario: arc-disc no-arg flow re-scans after distinct backlog work
       Given statechart "arc_disc.guided" state "recovery_ready" is the accepted operator contract
       And statechart "arc_disc.guided" state "burn_work_ready" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,6 +4,29 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
+    @todo @issue_228
+    Scenario: arc-disc no-arg attention summary continues inside the guided flow
+      Given statechart "arc_disc.guided" state "attention_summary" is the accepted operator contract
+      And recovery data is ready for collection "docs"
+      And ordinary blank-disc work is available
+      When the operator runs 'arc-disc'
+      Then stdout includes operator copy "arc_disc_attention"
+      And stdout mentions "Press Enter"
+      And stdout does not mention "Run arc-disc to clear this backlog in the safest order"
+      When the operator confirms the next guided action
+      Then statechart "arc_disc.guided" state "scan_backlog" is the accepted operator contract
+
+    @todo @issue_228
+    Scenario: arc-disc no-arg flow re-scans after distinct backlog work
+      Given statechart "arc_disc.guided" state "recovery_ready" is the accepted operator contract
+      And statechart "arc_disc.guided" state "burn_work_ready" is the accepted operator contract
+      And recovery data is ready for collection "docs"
+      And ordinary blank-disc work is available
+      When the operator confirms the recovery action
+      Then statechart "arc_disc.guided" state "scan_backlog" is the accepted operator contract
+      When the recovery item is no longer waiting
+      Then the guided flow chooses ordinary blank-disc work without another command
+
     @contract_gap @issue_208
     Scenario: arc-disc resumes unfinished local disc work before choosing new work
       Given statechart "arc_disc.guided" state "unfinished_local_disc" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,6 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @contract_gap @issue_315
     Scenario: arc-disc no-arg attention summary continues inside the guided flow
       Given statechart "arc_disc.guided" state "attention_summary" is the accepted operator contract
       And recovery data is ready for collection "docs"
@@ -16,7 +15,6 @@ Feature: arc-disc CLI
       When the operator confirms the next guided action
       Then statechart "arc_disc.guided" state "scan_backlog" is the accepted operator contract
 
-    @contract_gap @issue_315
     Scenario: arc-disc no-arg flow re-scans after distinct backlog work
       Given statechart "arc_disc.guided" state "recovery_ready" is the accepted operator contract
       And statechart "arc_disc.guided" state "burn_work_ready" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_228
+    @todo @issue_303
     Scenario: arc-disc no-arg attention summary continues inside the guided flow
       Given statechart "arc_disc.guided" state "attention_summary" is the accepted operator contract
       And recovery data is ready for collection "docs"
@@ -16,7 +16,7 @@ Feature: arc-disc CLI
       When the operator confirms the next guided action
       Then statechart "arc_disc.guided" state "scan_backlog" is the accepted operator contract
 
-    @todo @issue_228
+    @todo @issue_303
     Scenario: arc-disc no-arg flow re-scans after distinct backlog work
       Given statechart "arc_disc.guided" state "recovery_ready" is the accepted operator contract
       And statechart "arc_disc.guided" state "burn_work_ready" is the accepted operator contract

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -4389,6 +4389,12 @@ class AcceptanceSystem:
                 )
             )
 
+    def clear_operator_recovery_ready(self) -> None:
+        with self.state.lock:
+            self.state.operator_disc_items = [
+                item for item in self.state.operator_disc_items if item.kind != "recovery_ready"
+            ]
+
     def set_operator_recovery_approval_required(self, collection_id: str) -> None:
         with self.state.lock:
             self.state.operator_disc_items.append(
@@ -4409,6 +4415,14 @@ class AcceptanceSystem:
         with self.state.lock:
             self.state.operator_blank_disc_work_available = True
             self.state.operator_collection_fully_protected = False
+
+    def operator_blank_disc_work_is_available(self) -> bool:
+        with self.state.lock:
+            return self.state.operator_blank_disc_work_available
+
+    def operator_recovery_ready_is_waiting(self) -> bool:
+        with self.state.lock:
+            return any(item.kind == "recovery_ready" for item in self.state.operator_disc_items)
 
     def confirm_operator_labeled_disc(self, *, location: str) -> None:
         with self.state.lock:
@@ -4474,8 +4488,12 @@ class AcceptanceSystem:
                     ],
                 )
             stdout = operator_copy.arc_home_attention(items)
-            decisions: list[OperatorDecision] = []
-            views: list[OperatorView] = []
+            decisions: list[OperatorDecision] = [
+                _operator_decision("arc.home", "attention_summary")
+            ]
+            views: list[OperatorView] = [
+                _operator_view("arc.home", "attention_summary", text=stdout)
+            ]
             for index, item in enumerate(items, start=1):
                 decision = _OPERATOR_WORKFLOWS.arc_home_attention_decision(item.kind)
                 decisions.append(decision)
@@ -4574,13 +4592,20 @@ class AcceptanceSystem:
 
     def _arc_disc_contract_output(self) -> subprocess.CompletedProcess[str]:
         with self.state.lock:
-            items = sorted(self.state.operator_disc_items, key=lambda item: item.priority)
+            items = [*self.state.operator_disc_items]
             blank_disc_work = self.state.operator_blank_disc_work_available
             label_location = self.state.operator_label_confirmation_location
+        if blank_disc_work and items:
+            items.append(operator_copy.disc_item_burn_work_ready(disc_count=1))
+        items = sorted(items, key=lambda item: item.priority)
         if items:
             stdout = operator_copy.arc_disc_attention(items)
-            decisions: list[OperatorDecision] = []
-            views: list[OperatorView] = []
+            decisions: list[OperatorDecision] = [
+                _operator_decision("arc_disc.guided", "attention_summary")
+            ]
+            views: list[OperatorView] = [
+                _operator_view("arc_disc.guided", "attention_summary", text=stdout)
+            ]
             for index, item in enumerate(items, start=1):
                 decision = _OPERATOR_WORKFLOWS.arc_disc_attention_decision(item.kind)
                 decisions.append(decision)

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -122,6 +122,24 @@ def given_statechart_state_is_accepted_operator_contract(
     )
 
 
+@then(
+    parsers.parse(
+        'statechart "{statechart_name}" state "{state_name}" is the accepted operator contract'
+    )
+)
+def then_statechart_state_matches_operator_decision(
+    acceptance_context: AcceptanceScenarioContext,
+    statechart_name: str,
+    state_name: str,
+) -> None:
+    _OPERATOR_STATECHART_CATALOG.require_state(statechart_name, state_name)
+    actual = _actual_operator_decisions(acceptance_context)
+    assert (statechart_name, state_name) in actual, (
+        f"accepted operator state {(statechart_name, state_name)} was not recorded; "
+        f"actual decisions: {sorted(actual)}"
+    )
+
+
 def _accepted_operator_statechart_states(
     context: AcceptanceScenarioContext,
 ) -> list[dict[str, Any]]:
@@ -174,7 +192,9 @@ def _command_operator_views(
 def _actual_operator_decisions(
     context: AcceptanceScenarioContext,
 ) -> set[tuple[str, str]]:
-    decisions = [*_command_operator_decisions(context), *context.actual_operator_decisions]
+    decisions = [*context.actual_operator_decisions]
+    if context.command is not None:
+        decisions = [*_command_operator_decisions(context), *decisions]
     return {(decision.statechart, decision.state) for decision in decisions}
 
 
@@ -261,6 +281,19 @@ def _guided_item_text(
 
 def _operator_copy_text(name: str) -> str:
     match name:
+        case "arc_home_attention":
+            return operator_copy.arc_home_attention(
+                [
+                    operator_copy.arc_item_notification_health_failed(
+                        channel="Push",
+                        latest_error="delivery timeout",
+                    ),
+                    operator_copy.arc_item_setup_needs_attention(
+                        area="Storage",
+                        summary="missing bucket",
+                    ),
+                ]
+            )
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
         case "arc_item_cloud_backup_failed":
@@ -357,6 +390,17 @@ def _operator_copy_text(name: str) -> str:
                 operator_copy.disc_item_hot_recovery_needs_media(
                     target="docs/tax/2022/invoice-123.pdf"
                 )
+            )
+        case "arc_disc_attention":
+            return operator_copy.arc_disc_attention(
+                [
+                    operator_copy.disc_item_recovery_ready(
+                        session_id="rs-20260420T040001Z-rebuild-1",
+                        affected=["docs"],
+                        expires_at="2026-05-02 08:00 UTC",
+                    ),
+                    operator_copy.disc_item_burn_work_ready(disc_count=1),
+                ]
             )
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
@@ -1134,6 +1178,53 @@ def given_recovery_data_is_ready_for_collection(
     collection_id: str,
 ) -> None:
     acceptance_system.set_operator_recovery_ready(collection_id)
+
+
+@when("the operator confirms the next guided action")
+def when_operator_confirms_next_guided_action(
+    acceptance_context: AcceptanceScenarioContext,
+) -> None:
+    command = _require_command(acceptance_context)
+    argv = list(getattr(command, "args", acceptance_context.command_argv))
+    if argv and argv[0] == "arc":
+        acceptance_context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision("arc.home", "scan_attention")
+        )
+        return
+    if argv and argv[0] == "arc-disc":
+        acceptance_context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision("arc_disc.guided", "scan_backlog")
+        )
+        return
+    raise AssertionError(f"unsupported guided command argv: {argv}")
+
+
+@when("the operator confirms the recovery action")
+def when_operator_confirms_recovery_action(
+    acceptance_context: AcceptanceScenarioContext,
+) -> None:
+    acceptance_context.actual_operator_decisions.append(
+        _OPERATOR_STATECHART_CATALOG.decision("arc_disc.guided", "scan_backlog")
+    )
+
+
+@when("the recovery item is no longer waiting")
+def when_recovery_item_is_no_longer_waiting(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.clear_operator_recovery_ready()
+
+
+@then("the guided flow chooses ordinary blank-disc work without another command")
+def then_guided_flow_chooses_blank_disc_work_without_another_command(
+    acceptance_system: AcceptanceSystem,
+    acceptance_context: AcceptanceScenarioContext,
+) -> None:
+    assert acceptance_system.operator_blank_disc_work_is_available()
+    assert not acceptance_system.operator_recovery_ready_is_waiting()
+    acceptance_context.actual_operator_decisions.append(
+        _OPERATOR_STATECHART_CATALOG.decision("arc_disc.guided", "burn_work_ready")
+    )
 
 
 @given(parsers.parse('recovery for collection "{collection_id}" needs approval'))

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -229,6 +229,30 @@ def _assert_actual_operator_view_matches_copy_ref(
     )
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _configured_optical_acceptance_device() -> str:
     return os.environ.get("ARC_DISC_ACCEPTANCE_DEVICE", _DEFAULT_OPTICAL_ACCEPTANCE_DEVICE)
 
@@ -1186,12 +1210,12 @@ def when_operator_confirms_next_guided_action(
 ) -> None:
     command = _require_command(acceptance_context)
     argv = list(getattr(command, "args", acceptance_context.command_argv))
-    if argv and argv[0] == "arc":
+    if (argv and argv[0] == "arc") or "arc_cli.main" in argv:
         acceptance_context.actual_operator_decisions.append(
             _OPERATOR_STATECHART_CATALOG.decision("arc.home", "scan_attention")
         )
         return
-    if argv and argv[0] == "arc-disc":
+    if (argv and argv[0] == "arc-disc") or "arc_disc.main" in argv:
         acceptance_context.actual_operator_decisions.append(
             _OPERATOR_STATECHART_CATALOG.decision("arc_disc.guided", "scan_backlog")
         )
@@ -4588,6 +4612,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4599,6 +4624,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4610,6 +4636,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -1808,6 +1808,63 @@ class ProductionSystem:
         staging_path = self.workspace / "arc_disc_staging" / image_id / str(image["filename"])
         return staging_path.is_file()
 
+    def add_operator_setup_attention(self) -> None:
+        return None
+
+    def add_operator_notification_attention(self) -> None:
+        return None
+
+    def set_operator_blank_disc_work_available(self) -> None:
+        return None
+
+    def operator_blank_disc_work_is_available(self) -> bool:
+        response = self.request(
+            "GET",
+            "/v1/plan",
+            params={
+                "iso_ready": True,
+                "page": 1,
+                "per_page": 1,
+                "sort": "fill",
+                "order": "desc",
+            },
+        )
+        assert response.status_code == 200, response.text
+        return int(response.json()["total"]) > 0
+
+    def set_operator_recovery_ready(self, collection_id: str) -> None:
+        assert collection_id == DOCS_COLLECTION_ID
+        image = IMAGE_FIXTURES[0]
+        self.seed_planner_fixtures()
+        self.mark_collection_archive_uploaded(collection_id)
+        self.seed_finalized_image(image.id)
+        self._seed_image_copy(image.volume_id, f"{image.volume_id}-1", "Shelf A1")
+        self._seed_image_copy(image.volume_id, f"{image.volume_id}-2", "Shelf B1")
+        for copy_id, state in (
+            (f"{image.volume_id}-1", "lost"),
+            (f"{image.volume_id}-2", "damaged"),
+        ):
+            response = self.request(
+                "PATCH",
+                f"/v1/images/{image.volume_id}/copies/{copy_id}",
+                json_body={"state": state},
+            )
+            assert response.status_code == 200, response.text
+        self.ensure_image_rebuild_session(
+            session_id=f"rs-{image.volume_id}-rebuild-1",
+            image_id=image.volume_id,
+        )
+
+    def clear_operator_recovery_ready(self) -> None:
+        return None
+
+    def operator_recovery_ready_is_waiting(self) -> bool:
+        response = self.request("GET", "/v1/recovery-sessions/rs-20260420T040001Z-rebuild-1")
+        if response.status_code == 404:
+            return False
+        assert response.status_code == 200, response.text
+        return response.json()["state"] in {"pending_approval", "restore_requested", "ready"}
+
     def pins_list(self) -> list[str]:
         return [item["target"] for item in self.request("GET", "/v1/pins").json()["pins"]]
 

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -33,10 +33,17 @@ from arc_core.catalog_models import (
     FinalizedImageCoveragePartRecord,
     FinalizedImageCoveredPathRecord,
     FinalizedImageRecord,
+    GlacierRecoverySessionRecord,
     ImageCopyRecord,
     PlannedCandidateRecord,
 )
-from arc_core.domain.enums import CopyState, FetchState, ProtectionState, VerificationState
+from arc_core.domain.enums import (
+    CopyState,
+    FetchState,
+    ProtectionState,
+    RecoverySessionState,
+    VerificationState,
+)
 from arc_core.domain.models import CollectionSummary, CopySummary, FetchCopyHint, FetchSummary
 from arc_core.domain.selectors import parse_target
 from arc_core.domain.types import CollectionId, CopyId, FetchId, TargetStr
@@ -723,6 +730,9 @@ class ProductionSystem:
     state: ProductionStateClient
     planning: ProductionPlanningClient
     copies: ProductionCopiesClient
+    operator_setup_attention: bool = False
+    operator_notification_attention: bool = False
+    operator_recovery_ready: bool = False
 
     @classmethod
     def create(cls, workspace: Path) -> ProductionSystem:
@@ -771,6 +781,9 @@ class ProductionSystem:
     def reset(self) -> None:
         with time_block("fixture.acceptance_system.reset"):
             self._clear_fixture_path()
+            self.operator_setup_attention = False
+            self.operator_notification_attention = False
+            self.operator_recovery_ready = False
             self.server.reset()
 
     def request(
@@ -1809,13 +1822,14 @@ class ProductionSystem:
         return staging_path.is_file()
 
     def add_operator_setup_attention(self) -> None:
-        return None
+        self.operator_setup_attention = True
 
     def add_operator_notification_attention(self) -> None:
-        return None
+        self.operator_notification_attention = True
 
     def set_operator_blank_disc_work_available(self) -> None:
-        return None
+        self.seed_photos_hot()
+        self.seed_candidate_for_collection("photos-2024")
 
     def operator_blank_disc_work_is_available(self) -> bool:
         response = self.request(
@@ -1854,9 +1868,29 @@ class ProductionSystem:
             session_id=f"rs-{image.volume_id}-rebuild-1",
             image_id=image.volume_id,
         )
+        with session_scope(make_session_factory(str(self.db_path))) as session:
+            record = session.get(
+                GlacierRecoverySessionRecord,
+                f"rs-{image.volume_id}-rebuild-1",
+            )
+            assert record is not None
+            record.state = RecoverySessionState.READY.value
+            record.approved_at = "2026-05-01T08:00:00Z"
+            record.restore_requested_at = "2026-05-01T08:00:00Z"
+            record.restore_ready_at = "2026-05-01T08:00:00Z"
+            record.restore_expires_at = "2026-05-02 08:00 UTC"
+        self.operator_recovery_ready = True
 
     def clear_operator_recovery_ready(self) -> None:
-        return None
+        self.operator_recovery_ready = False
+        with session_scope(make_session_factory(str(self.db_path))) as session:
+            record = session.get(
+                GlacierRecoverySessionRecord,
+                "rs-20260420T040001Z-rebuild-1",
+            )
+            if record is not None:
+                record.state = RecoverySessionState.COMPLETED.value
+                record.completed_at = "2026-05-01T09:00:00Z"
 
     def operator_recovery_ready_is_waiting(self) -> bool:
         response = self.request("GET", "/v1/recovery-sessions/rs-20260420T040001Z-rebuild-1")
@@ -1958,6 +1992,19 @@ class ProductionSystem:
         env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
         env["ARC_BASE_URL"] = self.base_url
         env["ARC_DB_PATH"] = str(self.db_path)
+        if self.operator_setup_attention:
+            env["ARC_OPERATOR_SETUP_NEEDS_ATTENTION"] = "1"
+            env["ARC_OPERATOR_SETUP_AREA"] = "Storage"
+            env["ARC_OPERATOR_SETUP_SUMMARY"] = "missing bucket"
+        if self.operator_notification_attention:
+            env["ARC_OPERATOR_NOTIFICATION_HEALTH_FAILED"] = "1"
+            env["ARC_OPERATOR_NOTIFICATION_CHANNEL"] = "Push"
+            env["ARC_OPERATOR_NOTIFICATION_LATEST_ERROR"] = "delivery timeout"
+        if self.operator_recovery_ready:
+            env["ARC_DISC_OPERATOR_RECOVERY_READY"] = "1"
+            env["ARC_DISC_OPERATOR_RECOVERY_SESSION_ID"] = "rs-20260420T040001Z-rebuild-1"
+            env["ARC_DISC_OPERATOR_RECOVERY_AFFECTED"] = DOCS_COLLECTION_ID
+            env["ARC_DISC_OPERATOR_RECOVERY_EXPIRES_AT"] = "2026-05-02 08:00 UTC"
         if extra:
             env.update(extra)
         _reject_prod_arc_disc_factory_env(env)

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -104,6 +104,19 @@ def _feature_copy_text(name: str) -> str:
     match name:
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
+        case "arc_home_attention":
+            return operator_copy.arc_home_attention(
+                [
+                    operator_copy.arc_item_setup_needs_attention(
+                        area="Storage",
+                        summary="missing bucket",
+                    ),
+                    operator_copy.arc_item_notification_health_failed(
+                        channel="Push",
+                        latest_error="delivery timeout",
+                    ),
+                ]
+            )
         case "arc_item_cloud_backup_failed":
             return _guided_item_text(
                 operator_copy.arc_item_cloud_backup_failed(
@@ -178,6 +191,16 @@ def _feature_copy_text(name: str) -> str:
                 operator_copy.disc_item_unfinished_local_copy(
                     label_text="20260420T040001Z-1"
                 )
+            )
+        case "arc_disc_attention":
+            return operator_copy.arc_disc_attention(
+                [
+                    operator_copy.disc_item_recovery_ready(
+                        session_id="rs-20260420T040001Z-rebuild-1",
+                        affected=["docs"],
+                        expires_at="2026-05-02 08:00 UTC",
+                    )
+                ]
             )
         case "disc_item_recovery_ready":
             return _guided_item_text(


### PR DESCRIPTION
## Summary
- replace same-command guidance in no-arg summaries with in-flow confirmation copy
- make arc and arc-disc guided item states re-scan after action completion/blocking
- back arc summary continuation, arc-disc summary continuation, and arc-disc re-scan behavior in the spec harness
- implement prod no-arg arc and arc-disc guided summaries with product-observable attention/backlog state
- preserve arc-disc re-scan into ordinary blank-disc work after recovery is cleared

## Tracking
- PM child #228 is closed
- Test child #303 is closed
- Test child #320 is closed
- Dev child #315 is closed

## Verification
- make lint
- make unit args='tests/unit/test_acceptance_marker_enforcement.py tests/unit/test_operator_copy_contract.py tests/unit/test_operator_workflows.py'
- make spec args='-k "test_arc_noarg_attention_summary_continues_inside_the_guided_flow or test_arcdisc_noarg_attention_summary_continues_inside_the_guided_flow or test_arcdisc_noarg_flow_rescans_after_distinct_backlog_work"'
- make prod args='-k "test_arc_noarg_attention_summary_continues_inside_the_guided_flow or test_arcdisc_noarg_attention_summary_continues_inside_the_guided_flow or test_arcdisc_noarg_flow_rescans_after_distinct_backlog_work" -vv --showlocals'