### PR TITLE
Meta: Clarify arc-disc recovery rebuild work remaining

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -745,10 +745,10 @@ def recovery_expired(*, session_id: str) -> str:
     )
 
 
-def recovery_cleanup_handoff(*, affected: Iterable[str]) -> str:
+def recovery_rebuild_work_remaining(*, affected: Iterable[str]) -> str:
     return (
-        f"Recovery cleanup is ready for {list_sentence(affected)}. "
-        "Riverhog will keep the safe recovery handoff."
+        f"Replacement-disc recovery work remains for {list_sentence(affected)}. "
+        f"Run {command(ARC_DISC)} to continue the guided recovery work."
     )
 
 

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -425,8 +425,8 @@ statecharts:
             target: ready
           - guard: ready_window_expired
             target: expired
-          - guard: recovery_cleanup_handoff_ready
-            target: cleanup_handoff
+          - guard: image_rebuild_work_remaining
+            target: rebuild_work_remaining
         type: choice
       approval_required:
         view: recovery_approval_required
@@ -458,8 +458,8 @@ statecharts:
       expired:
         view: recovery_expired
         final: true
-      cleanup_handoff:
-        view: recovery_cleanup_handoff
+      rebuild_work_remaining:
+        view: recovery_rebuild_work_remaining
         final: true
   arc_disc.hot_recovery:
     command: arc-disc
@@ -802,7 +802,7 @@ handoffs:
       state: scan_backlog
   - from:
       statechart: arc_disc.recovery
-      state: cleanup_handoff
+      state: rebuild_work_remaining
     label: operator checks remaining recovery work
     target:
       statechart: arc_disc.guided

--- a/docs/how-to/run-a-guided-burn-session.md
+++ b/docs/how-to/run-a-guided-burn-session.md
@@ -2,8 +2,8 @@
 
 The `arc-disc burn` command walks the current burn backlog from the fullest ready image downward.
 If a finalized image has lost all protected copies, Riverhog tracks that image
-through an `image_rebuild` recovery session instead; `arc-disc burn` reports
-that handoff and does not treat it as ordinary replacement backlog.
+through recovery instead; `arc-disc burn` reports that replacement-disc recovery
+work remains and does not treat it as ordinary replacement backlog.
 
 ## Host requirements
 

--- a/docs/reference/disc.md
+++ b/docs/reference/disc.md
@@ -231,10 +231,10 @@ after one or more finalized images lose all protected copies.
   artifacts already on disk
 - recovery burns reuse the same local checkpoint behavior as `arc-disc burn`, including resume from unfinished
   burned-media verification or label confirmation
-- when the recovery session finishes, Riverhog marks the session completed,
-  records archive restore cleanup or lifecycle handoff for the collection
-  archives, and deletes the staged ISO artifacts for the rebuilt images
-  immediately
+- when ordinary burn backlog is clear but replacement-disc recovery work remains, Riverhog reports the remaining
+  recovery work instead of exposing a cleanup handoff
+- when the recovery session finishes, Riverhog marks the session completed and deletes the staged ISO artifacts for the
+  rebuilt images immediately; archive restore cleanup remains an internal lifecycle detail
 
 ## Manual Recovery
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_304: tracks issue #304 for backing recovery-rebuild-work-remaining-PM-scenario",
+  "issue_314: tracks issue #314 for implementing recovery rebuild-work-remaining copy",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_304: tracks issue #304 for backing recovery-rebuild-work-remaining-PM-scenario",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -512,8 +512,8 @@ def render_operator_copy(reference: str) -> str:
             return operator_copy.recovery_expired(
                 session_id="rs-20260420T040001Z-rebuild-1"
             )
-        case "recovery_cleanup_handoff":
-            return operator_copy.recovery_cleanup_handoff(affected=["docs"])
+        case "recovery_rebuild_work_remaining":
+            return operator_copy.recovery_rebuild_work_remaining(affected=["docs"])
         case "hot_recovery_insert_disc":
             return operator_copy.hot_recovery_insert_disc(
                 target="docs/tax/2022/invoice-123.pdf",

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,6 +18,7 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
 app = typer.Typer(help="arc optical recovery CLI")
 
@@ -161,6 +162,7 @@ class RecoveryHandoff:
 class RecoverySessionImageHint:
     image_id: str
     filename: str
+    collection_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -705,6 +707,11 @@ def _recovery_session_hint_from_payload(payload: dict[str, Any]) -> RecoverySess
         RecoverySessionImageHint(
             image_id=str(image["id"]),
             filename=str(image["filename"]),
+            collection_ids=tuple(
+                str(collection_id)
+                for collection_id in image.get("collection_ids", [])
+                if collection_id is not None
+            ),
         )
         for image in images_payload
         if isinstance(image, dict)
@@ -746,6 +753,24 @@ def _report_recovery_sessions(sessions: list[RecoverySessionHint]) -> None:
         typer.echo(f"images: {image_ids}")
         if session.latest_message:
             typer.echo(session.latest_message)
+
+
+def _rebuild_work_remaining_collections(
+    sessions: list[RecoverySessionHint],
+) -> tuple[str, ...]:
+    if not sessions:
+        return ()
+
+    collection_ids: list[str] = []
+    for session in sessions:
+        if session.type != "image_rebuild" or len(session.images) != 1:
+            return ()
+        image = session.images[0]
+        if not image.collection_ids:
+            return ()
+        collection_ids.extend(image.collection_ids)
+
+    return tuple(dict.fromkeys(collection_ids))
 
 
 def _clear_recovery_artifacts(
@@ -1398,6 +1423,9 @@ def recover_cmd(
         client = ApiClient()
         sessions = _discover_active_recovery_sessions(client)
         if session_id is None:
+            if affected := _rebuild_work_remaining_collections(sessions):
+                typer.echo(operator_copy.recovery_rebuild_work_remaining(affected=affected))
+                return
             _report_recovery_sessions(sessions)
             return
 

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,6 +1,17 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
+  @todo @issue_230
+  Scenario: arc-disc recovery names remaining replacement-disc work instead of cleanup handoff
+    Given statechart "arc_disc.recovery" state "rebuild_work_remaining" is the accepted operator contract
+    And ordinary burn backlog is clear
+    And replacement-disc recovery work remains for collection "docs"
+    When the operator runs 'arc-disc recover'
+    Then stdout includes operator copy "recovery_rebuild_work_remaining"
+    And stdout mentions "Replacement-disc recovery work remains"
+    And stdout does not mention "Cleanup Handoff"
+    And stdout does not mention "safe recovery handoff"
+
   Scenario: arc-disc recover lists one multi-image pending rebuild session
     Given an archive with planned images
     And an archive with split planned images

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,7 +1,6 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
-  @contract_gap @issue_314
   Scenario: arc-disc recovery names remaining replacement-disc work instead of cleanup handoff
     Given statechart "arc_disc.recovery" state "rebuild_work_remaining" is the accepted operator contract
     And ordinary burn backlog is clear

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,7 +1,7 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
-  @todo @issue_304
+  @contract_gap @issue_314
   Scenario: arc-disc recovery names remaining replacement-disc work instead of cleanup handoff
     Given statechart "arc_disc.recovery" state "rebuild_work_remaining" is the accepted operator contract
     And ordinary burn backlog is clear

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,7 +1,7 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
-  @todo @issue_230
+  @todo @issue_304
   Scenario: arc-disc recovery names remaining replacement-disc work instead of cleanup handoff
     Given statechart "arc_disc.recovery" state "rebuild_work_remaining" is the accepted operator contract
     And ordinary burn backlog is clear

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -541,6 +541,7 @@ class AcceptanceState:
     next_fetch_number: int = 0
     operator_arc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
     operator_disc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
+    operator_rebuild_work_remaining_collections: tuple[str, ...] = ()
     operator_blank_disc_work_available: bool = False
     operator_label_confirmation_location: str | None = None
     operator_collection_fully_protected: bool = False
@@ -4399,6 +4400,10 @@ class AcceptanceSystem:
                 )
             )
 
+    def set_operator_rebuild_work_remaining(self, collection_id: str) -> None:
+        with self.state.lock:
+            self.state.operator_rebuild_work_remaining_collections = (collection_id,)
+
     def set_operator_hot_recovery_needs_media(self, target: str) -> None:
         with self.state.lock:
             self.state.operator_disc_items.append(
@@ -4672,6 +4677,25 @@ class AcceptanceSystem:
     def run_arc_disc(
         self, *args: str, input_text: str = "\n" * 16
     ) -> subprocess.CompletedProcess[str]:
+        if args == ("recover",):
+            with self.state.lock:
+                affected = self.state.operator_rebuild_work_remaining_collections
+            if affected:
+                stdout = operator_copy.recovery_rebuild_work_remaining(affected=affected)
+                return _operator_completed_process(
+                    ["arc-disc", *args],
+                    stdout=stdout,
+                    decisions=[
+                        _operator_decision("arc_disc.recovery", "rebuild_work_remaining")
+                    ],
+                    views=[
+                        _operator_view(
+                            "arc_disc.recovery",
+                            "rebuild_work_remaining",
+                            text=stdout,
+                        )
+                    ],
+                )
         if not args:
             return self._arc_disc_contract_output()
         if not self.fixture_path.exists():

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -358,6 +358,8 @@ def _operator_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "recovery_rebuild_work_remaining":
+            return operator_copy.recovery_rebuild_work_remaining(affected=["docs"])
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
@@ -1142,6 +1144,19 @@ def given_recovery_for_collection_needs_approval(
     collection_id: str,
 ) -> None:
     acceptance_system.set_operator_recovery_approval_required(collection_id)
+
+
+@given("ordinary burn backlog is clear")
+def given_ordinary_burn_backlog_is_clear() -> None:
+    return None
+
+
+@given(parsers.parse('replacement-disc recovery work remains for collection "{collection_id}"'))
+def given_replacement_disc_recovery_work_remains(
+    acceptance_system: AcceptanceSystem,
+    collection_id: str,
+) -> None:
+    acceptance_system.set_operator_rebuild_work_remaining(collection_id)
 
 
 @given("pinned files need recovery from disc")

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -209,6 +209,30 @@ def _assert_actual_operator_view_matches_copy_ref(
     )
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _configured_optical_acceptance_device() -> str:
     return os.environ.get("ARC_DISC_ACCEPTANCE_DEVICE", _DEFAULT_OPTICAL_ACCEPTANCE_DEVICE)
 
@@ -4512,6 +4536,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4523,6 +4548,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4534,6 +4560,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -1808,6 +1808,29 @@ class ProductionSystem:
         staging_path = self.workspace / "arc_disc_staging" / image_id / str(image["filename"])
         return staging_path.is_file()
 
+    def set_operator_rebuild_work_remaining(self, collection_id: str) -> None:
+        assert collection_id == DOCS_COLLECTION_ID
+        image = IMAGE_FIXTURES[0]
+        self.seed_planner_fixtures()
+        self.mark_collection_archive_uploaded(collection_id)
+        self.seed_finalized_image(image.id)
+        self._seed_image_copy(image.volume_id, f"{image.volume_id}-1", "Shelf A1")
+        self._seed_image_copy(image.volume_id, f"{image.volume_id}-2", "Shelf B1")
+        for copy_id, state in (
+            (f"{image.volume_id}-1", "lost"),
+            (f"{image.volume_id}-2", "damaged"),
+        ):
+            response = self.request(
+                "PATCH",
+                f"/v1/images/{image.volume_id}/copies/{copy_id}",
+                json_body={"state": state},
+            )
+            assert response.status_code == 200, response.text
+        self.ensure_image_rebuild_session(
+            session_id=f"rs-{image.volume_id}-rebuild-1",
+            image_id=image.volume_id,
+        )
+
     def pins_list(self) -> list[str]:
         return [item["target"] for item in self.request("GET", "/v1/pins").json()["pins"]]
 

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -205,6 +205,8 @@ def _feature_copy_text(name: str) -> str:
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
             return operator_copy.burn_label_checkpoint(label_text="20260420T040001Z-1")
+        case "recovery_rebuild_work_remaining":
+            return operator_copy.recovery_rebuild_work_remaining(affected=["docs"])
     raise AssertionError(f"unsupported operator copy reference: {name}")
 
 


### PR DESCRIPTION
## Summary
- replace cleanup handoff state/guard/copy with rebuild-work-remaining terminology
- update recovery and guided-burn docs to avoid cleanup handoff language
- back the remaining replacement-disc recovery work scenario in the spec harness
- back prod replacement-disc recovery setup and product behavior so arc-disc recover names remaining replacement-disc work
- keep multi-image pending rebuild session listing behavior intact

## Tracking
- PM child #230 is closed
- Test child #304 is closed
- Test child #321 is closed
- Dev child #314 is closed

## Verification
- make lint
- make unit args='tests/unit/test_acceptance_marker_enforcement.py'
- make unit args='tests/unit/test_arc_disc.py -k "active_recovery_sessions or all_pending_recovery_seed_slots"'
- make spec args='-k "test_arcdisc_recovery_names_remaining_replacementdisc_work_instead_of_cleanup_handoff"'
- make prod args='-k "test_arcdisc_recovery_names_remaining_replacementdisc_work_instead_of_cleanup_handoff" -vv --showlocals'
- make spec args='-k "test_arcdisc_recover_lists_one_multiimage_pending_rebuild_session"'
- make prod args='-k "test_arcdisc_recover_lists_one_multiimage_pending_rebuild_session"'