### PR TITLE
Meta: Route expired recovery through re-approval

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -738,10 +738,25 @@ def recovery_completed(*, session_id: str) -> str:
     return f"Recovery {session_id} is complete."
 
 
-def recovery_expired(*, session_id: str) -> str:
+def recovery_expired_local_resume(*, session_id: str) -> str:
     return (
-        f"Recovery {session_id} is no longer ready. "
-        f"Run {command(ARC_DISC)} to review the next safe recovery step."
+        f"Recovery {session_id} is no longer ready in cloud backup, but local "
+        "staged recovery files are still available. Resume from local files; "
+        "Riverhog will not request cloud backup files again."
+    )
+
+
+def recovery_expired_needs_reapproval(
+    *,
+    session_id: str,
+    affected: Iterable[str],
+    estimated_cost: object | None,
+) -> str:
+    return (
+        f"Recovery {session_id} expired before replacement discs were finished for "
+        f"{list_sentence(affected)}.\n"
+        f"Estimated cost: {money_usd(estimated_cost)}. Approve again before "
+        "Riverhog requests cloud backup files."
     )
 
 

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -423,8 +423,10 @@ statecharts:
             target: waiting
           - guard: recovered_data_ready
             target: ready
-          - guard: ready_window_expired
-            target: expired
+          - guard: expired_local_artifacts_available
+            target: expired_local_resume
+          - guard: expired_restore_must_be_requested_again
+            target: expired_needs_reapproval
           - guard: recovery_cleanup_handoff_ready
             target: cleanup_handoff
         type: choice
@@ -443,21 +445,30 @@ statecharts:
         transitions:
           - guard: recovered_data_ready
             target: ready
-          - guard: ready_window_expired
-            target: expired
+          - guard: expired_restore_must_be_requested_again
+            target: expired_needs_reapproval
       ready:
         view: recovery_ready
         transitions:
           - event: operator_makes_replacement_disc
             target: completed
-          - guard: ready_window_expired
-            target: expired
+          - guard: expired_local_artifacts_available
+            target: expired_local_resume
+          - guard: expired_restore_must_be_requested_again
+            target: expired_needs_reapproval
       completed:
         view: recovery_completed
         final: true
-      expired:
-        view: recovery_expired
-        final: true
+      expired_local_resume:
+        view: recovery_expired_local_resume
+        transitions:
+          - event: operator_resumes_from_local_artifacts
+            target: ready
+      expired_needs_reapproval:
+        view: recovery_expired_needs_reapproval
+        transitions:
+          - event: operator_reviews_reapproval
+            target: approval_required
       cleanup_handoff:
         view: recovery_cleanup_handoff
         final: true
@@ -795,8 +806,8 @@ handoffs:
       state: scan_backlog
   - from:
       statechart: arc_disc.recovery
-      state: expired
-    label: operator checks remaining recovery work
+      state: expired_local_resume
+    label: operator resumes local recovery artifacts
     target:
       statechart: arc_disc.guided
       state: scan_backlog

--- a/docs/reference/disc.md
+++ b/docs/reference/disc.md
@@ -228,7 +228,9 @@ after one or more finalized images lose all protected copies.
 - ready sessions stage ISO bytes rebuilt from restored collection archives and
   persisted image coverage metadata
 - if the restore window expires after local staging succeeded, `arc-disc recover` can still resume from the staged ISO
-  artifacts already on disk
+  artifacts already on disk without another cloud request
+- if the restore window expires before local staging is available, Riverhog returns to recovery approval before
+  requesting cloud backup files again
 - recovery burns reuse the same local checkpoint behavior as `arc-disc burn`, including resume from unfinished
   burned-media verification or label confirmation
 - when the recovery session finishes, Riverhog marks the session completed,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_305: tracks issue #305 for backing expired-recovery-reapproval-PM-scenarios",
+  "issue_313: tracks issue #313 for implementing expired recovery re-approval routing",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_305: tracks issue #305 for backing expired-recovery-reapproval-PM-scenarios",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -508,9 +508,15 @@ def render_operator_copy(reference: str) -> str:
             return operator_copy.recovery_completed(
                 session_id="rs-20260420T040001Z-rebuild-1"
             )
-        case "recovery_expired":
-            return operator_copy.recovery_expired(
+        case "recovery_expired_local_resume":
+            return operator_copy.recovery_expired_local_resume(
                 session_id="rs-20260420T040001Z-rebuild-1"
+            )
+        case "recovery_expired_needs_reapproval":
+            return operator_copy.recovery_expired_needs_reapproval(
+                session_id="rs-20260420T040001Z-rebuild-1",
+                affected=["docs"],
+                estimated_cost="12.34",
             )
         case "recovery_cleanup_handoff":
             return operator_copy.recovery_cleanup_handoff(affected=["docs"])

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,6 +18,7 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
 app = typer.Typer(help="arc optical recovery CLI")
 
@@ -170,6 +171,8 @@ class RecoverySessionHint:
     state: str
     latest_message: str | None
     images: tuple[RecoverySessionImageHint, ...]
+    affected: tuple[str, ...] = ()
+    estimated_cost: object | None = None
 
 
 _PENDING_BURN_STATES = {"needed", "burning"}
@@ -717,7 +720,34 @@ def _recovery_session_hint_from_payload(payload: dict[str, Any]) -> RecoverySess
             str(payload["latest_message"]) if payload.get("latest_message") is not None else None
         ),
         images=images,
+        affected=_recovery_session_affected(payload),
+        estimated_cost=_recovery_session_estimated_cost(payload),
     )
+
+
+def _recovery_session_affected(payload: dict[str, Any]) -> tuple[str, ...]:
+    affected: set[str] = set()
+    collections = payload.get("collections", [])
+    if isinstance(collections, list):
+        for collection in collections:
+            if isinstance(collection, dict) and collection.get("id") is not None:
+                affected.add(str(collection["id"]))
+    images = payload.get("images", [])
+    if isinstance(images, list):
+        for image in images:
+            if not isinstance(image, dict):
+                continue
+            collection_ids = image.get("collection_ids", [])
+            if isinstance(collection_ids, list):
+                affected.update(str(collection_id) for collection_id in collection_ids)
+    return tuple(sorted(affected))
+
+
+def _recovery_session_estimated_cost(payload: dict[str, Any]) -> object | None:
+    cost_estimate = payload.get("cost_estimate")
+    if not isinstance(cost_estimate, dict):
+        return None
+    return cost_estimate.get("total_estimated_cost_usd")
 
 
 def _discover_active_recovery_sessions(client: ApiClient) -> list[RecoverySessionHint]:
@@ -886,10 +916,26 @@ def _process_recovery_session(
             client=client,
             staging_dir=staging_dir,
         ):
-            raise RuntimeError(
-                recovery_session.latest_message
-                or f"recovery session expired and must be re-initiated: {session_id}"
+            typer.echo(
+                operator_copy.recovery_expired_needs_reapproval(
+                    session_id=session_id,
+                    affected=recovery_session.affected or ("affected data",),
+                    estimated_cost=recovery_session.estimated_cost,
+                )
             )
+            return (
+                RecoverySessionHint(
+                    session_id=recovery_session.session_id,
+                    type=recovery_session.type,
+                    state="restore_requested",
+                    latest_message=None,
+                    images=recovery_session.images,
+                    affected=recovery_session.affected,
+                    estimated_cost=recovery_session.estimated_cost,
+                ),
+                [],
+            )
+        typer.echo(operator_copy.recovery_expired_local_resume(session_id=session_id))
         typer.echo(
             "restore window expired remotely; resuming from local staged ISO artifacts",
             err=True,

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,7 +1,6 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
-  @contract_gap @issue_313
   Scenario: expired recovery with local artifacts resumes without another approval
     Given statechart "arc_disc.recovery" state "expired_local_resume" is the accepted operator contract
     And recovery session "rs-20260420T040001Z-rebuild-1" has expired
@@ -11,7 +10,6 @@ Feature: arc-disc recover CLI
     And stdout mentions "local staged recovery files"
     And stdout does not mention "Approve again"
 
-  @contract_gap @issue_313
   Scenario: expired recovery without local artifacts returns to approval
     Given statechart "arc_disc.recovery" state "expired_needs_reapproval" is the accepted operator contract
     And recovery session "rs-20260420T040001Z-rebuild-1" has expired

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,7 +1,7 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
-  @todo @issue_305
+  @contract_gap @issue_313
   Scenario: expired recovery with local artifacts resumes without another approval
     Given statechart "arc_disc.recovery" state "expired_local_resume" is the accepted operator contract
     And recovery session "rs-20260420T040001Z-rebuild-1" has expired
@@ -11,7 +11,7 @@ Feature: arc-disc recover CLI
     And stdout mentions "local staged recovery files"
     And stdout does not mention "Approve again"
 
-  @todo @issue_305
+  @contract_gap @issue_313
   Scenario: expired recovery without local artifacts returns to approval
     Given statechart "arc_disc.recovery" state "expired_needs_reapproval" is the accepted operator contract
     And recovery session "rs-20260420T040001Z-rebuild-1" has expired

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,7 +1,7 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
-  @todo @issue_231
+  @todo @issue_305
   Scenario: expired recovery with local artifacts resumes without another approval
     Given statechart "arc_disc.recovery" state "expired_local_resume" is the accepted operator contract
     And recovery session "rs-20260420T040001Z-rebuild-1" has expired
@@ -11,7 +11,7 @@ Feature: arc-disc recover CLI
     And stdout mentions "local staged recovery files"
     And stdout does not mention "Approve again"
 
-  @todo @issue_231
+  @todo @issue_305
   Scenario: expired recovery without local artifacts returns to approval
     Given statechart "arc_disc.recovery" state "expired_needs_reapproval" is the accepted operator contract
     And recovery session "rs-20260420T040001Z-rebuild-1" has expired

--- a/tests/acceptance/features/cli.arc_disc_recover.feature
+++ b/tests/acceptance/features/cli.arc_disc_recover.feature
@@ -1,6 +1,27 @@
 @acceptance @cli @mvp
 Feature: arc-disc recover CLI
   The optical CLI discovers and resumes image rebuild sessions for finalized images that lost all protected copies.
+  @todo @issue_231
+  Scenario: expired recovery with local artifacts resumes without another approval
+    Given statechart "arc_disc.recovery" state "expired_local_resume" is the accepted operator contract
+    And recovery session "rs-20260420T040001Z-rebuild-1" has expired
+    And local staged recovery artifacts are available
+    When the operator runs arc-disc recover "rs-20260420T040001Z-rebuild-1"
+    Then stdout includes operator copy "recovery_expired_local_resume"
+    And stdout mentions "local staged recovery files"
+    And stdout does not mention "Approve again"
+
+  @todo @issue_231
+  Scenario: expired recovery without local artifacts returns to approval
+    Given statechart "arc_disc.recovery" state "expired_needs_reapproval" is the accepted operator contract
+    And recovery session "rs-20260420T040001Z-rebuild-1" has expired
+    And local staged recovery artifacts are absent
+    When the operator runs arc-disc recover "rs-20260420T040001Z-rebuild-1"
+    Then stdout includes operator copy "recovery_expired_needs_reapproval"
+    And stdout mentions "Approve again"
+    And stdout mentions "Estimated cost"
+    And stdout does not mention "Run arc-disc to review the next safe recovery step"
+
   Scenario: arc-disc recover lists one multi-image pending rebuild session
     Given an archive with planned images
     And an archive with split planned images

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -541,6 +541,8 @@ class AcceptanceState:
     next_fetch_number: int = 0
     operator_arc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
     operator_disc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
+    operator_expired_recovery_session_id: str | None = None
+    operator_expired_recovery_local_artifacts_available: bool | None = None
     operator_blank_disc_work_available: bool = False
     operator_label_confirmation_location: str | None = None
     operator_collection_fully_protected: bool = False
@@ -4399,6 +4401,14 @@ class AcceptanceSystem:
                 )
             )
 
+    def set_operator_expired_recovery_session(self, session_id: str) -> None:
+        with self.state.lock:
+            self.state.operator_expired_recovery_session_id = session_id
+
+    def set_operator_expired_recovery_local_artifacts(self, *, available: bool) -> None:
+        with self.state.lock:
+            self.state.operator_expired_recovery_local_artifacts_available = available
+
     def set_operator_hot_recovery_needs_media(self, target: str) -> None:
         with self.state.lock:
             self.state.operator_disc_items.append(
@@ -4672,6 +4682,38 @@ class AcceptanceSystem:
     def run_arc_disc(
         self, *args: str, input_text: str = "\n" * 16
     ) -> subprocess.CompletedProcess[str]:
+        if len(args) >= 2 and args[0] == "recover":
+            session_id = args[1]
+            with self.state.lock:
+                expired_session_id = self.state.operator_expired_recovery_session_id
+                local_artifacts_available = (
+                    self.state.operator_expired_recovery_local_artifacts_available
+                )
+            if expired_session_id == session_id and local_artifacts_available is not None:
+                if local_artifacts_available:
+                    stdout = operator_copy.recovery_expired_local_resume(
+                        session_id=session_id
+                    )
+                    state = "expired_local_resume"
+                else:
+                    stdout = operator_copy.recovery_expired_needs_reapproval(
+                        session_id=session_id,
+                        affected=["docs"],
+                        estimated_cost="12.34",
+                    )
+                    state = "expired_needs_reapproval"
+                return _operator_completed_process(
+                    ["arc-disc", *args],
+                    stdout=stdout,
+                    decisions=[_operator_decision("arc_disc.recovery", state)],
+                    views=[
+                        _operator_view(
+                            "arc_disc.recovery",
+                            state,
+                            text=stdout,
+                        )
+                    ],
+                )
         if not args:
             return self._arc_disc_contract_output()
         if not self.fixture_path.exists():

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -184,6 +184,30 @@ def _actual_operator_views(
     return (*_command_operator_views(context), *context.actual_operator_views)
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _assert_actual_operator_view_matches_copy_ref(
     context: AcceptanceScenarioContext,
     name: str,
@@ -4529,6 +4553,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4540,6 +4565,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4551,6 +4577,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -358,6 +358,16 @@ def _operator_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "recovery_expired_local_resume":
+            return operator_copy.recovery_expired_local_resume(
+                session_id="rs-20260420T040001Z-rebuild-1"
+            )
+        case "recovery_expired_needs_reapproval":
+            return operator_copy.recovery_expired_needs_reapproval(
+                session_id="rs-20260420T040001Z-rebuild-1",
+                affected=["docs"],
+                estimated_cost="12.34",
+            )
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
@@ -1142,6 +1152,28 @@ def given_recovery_for_collection_needs_approval(
     collection_id: str,
 ) -> None:
     acceptance_system.set_operator_recovery_approval_required(collection_id)
+
+
+@given(parsers.parse('recovery session "{session_id}" has expired'))
+def given_recovery_session_has_expired(
+    acceptance_system: AcceptanceSystem,
+    session_id: str,
+) -> None:
+    acceptance_system.set_operator_expired_recovery_session(session_id)
+
+
+@given("local staged recovery artifacts are available")
+def given_local_staged_recovery_artifacts_are_available(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_expired_recovery_local_artifacts(available=True)
+
+
+@given("local staged recovery artifacts are absent")
+def given_local_staged_recovery_artifacts_are_absent(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_expired_recovery_local_artifacts(available=False)
 
 
 @given("pinned files need recovery from disc")

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -1850,13 +1850,18 @@ class ProductionSystem:
                 "Restored ISO data expired and cleanup was recorded; re-initiate "
                 "recovery to request a new restore."
             )
+            estimate = json.loads(record.estimate_json)
+            estimate["total_estimated_cost_usd"] = 12.34
+            record.estimate_json = json.dumps(estimate)
 
     def set_operator_expired_recovery_local_artifacts(self, *, available: bool) -> None:
         image = IMAGE_FIXTURES[0]
         staging_path = self.workspace / "arc_disc_staging" / image.volume_id / image.filename
         if available:
             staging_path.parent.mkdir(parents=True, exist_ok=True)
-            staging_path.write_bytes(b"fixture staged recovery ISO\n")
+            response = self.request("GET", f"/v1/images/{image.volume_id}/iso")
+            assert response.status_code == 200, response.text
+            staging_path.write_bytes(response.content)
             return
         if staging_path.parent.exists():
             shutil.rmtree(staging_path.parent)

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -33,10 +33,17 @@ from arc_core.catalog_models import (
     FinalizedImageCoveragePartRecord,
     FinalizedImageCoveredPathRecord,
     FinalizedImageRecord,
+    GlacierRecoverySessionRecord,
     ImageCopyRecord,
     PlannedCandidateRecord,
 )
-from arc_core.domain.enums import CopyState, FetchState, ProtectionState, VerificationState
+from arc_core.domain.enums import (
+    CopyState,
+    FetchState,
+    ProtectionState,
+    RecoverySessionState,
+    VerificationState,
+)
 from arc_core.domain.models import CollectionSummary, CopySummary, FetchCopyHint, FetchSummary
 from arc_core.domain.selectors import parse_target
 from arc_core.domain.types import CollectionId, CopyId, FetchId, TargetStr
@@ -1807,6 +1814,52 @@ class ProductionSystem:
         image = self.request("GET", f"/v1/images/{image_id}").json()
         staging_path = self.workspace / "arc_disc_staging" / image_id / str(image["filename"])
         return staging_path.is_file()
+
+    def set_operator_expired_recovery_session(self, session_id: str) -> None:
+        image = IMAGE_FIXTURES[0]
+        assert session_id == f"rs-{image.volume_id}-rebuild-1"
+        self.seed_planner_fixtures()
+        self.mark_collection_archive_uploaded(DOCS_COLLECTION_ID)
+        self.seed_finalized_image(image.id)
+        self._seed_image_copy(image.volume_id, f"{image.volume_id}-1", "Shelf A1")
+        self._seed_image_copy(image.volume_id, f"{image.volume_id}-2", "Shelf B1")
+        for copy_id, state in (
+            (f"{image.volume_id}-1", "lost"),
+            (f"{image.volume_id}-2", "damaged"),
+        ):
+            response = self.request(
+                "PATCH",
+                f"/v1/images/{image.volume_id}/copies/{copy_id}",
+                json_body={"state": state},
+            )
+            assert response.status_code == 200, response.text
+        self.ensure_image_rebuild_session(
+            session_id=session_id,
+            image_id=image.volume_id,
+        )
+        with session_scope(make_session_factory(str(self.db_path))) as session:
+            record = session.get(GlacierRecoverySessionRecord, session_id)
+            assert record is not None, f"recovery session not found: {session_id}"
+            record.state = RecoverySessionState.EXPIRED.value
+            record.approved_at = "2026-04-20T05:00:00Z"
+            record.restore_requested_at = "2026-04-20T05:00:00Z"
+            record.restore_ready_at = "2026-04-20T06:00:00Z"
+            record.restore_next_poll_at = None
+            record.restore_expires_at = "2000-01-01T00:00:00Z"
+            record.latest_message = (
+                "Restored ISO data expired and cleanup was recorded; re-initiate "
+                "recovery to request a new restore."
+            )
+
+    def set_operator_expired_recovery_local_artifacts(self, *, available: bool) -> None:
+        image = IMAGE_FIXTURES[0]
+        staging_path = self.workspace / "arc_disc_staging" / image.volume_id / image.filename
+        if available:
+            staging_path.parent.mkdir(parents=True, exist_ok=True)
+            staging_path.write_bytes(b"fixture staged recovery ISO\n")
+            return
+        if staging_path.parent.exists():
+            shutil.rmtree(staging_path.parent)
 
     def pins_list(self) -> list[str]:
         return [item["target"] for item in self.request("GET", "/v1/pins").json()["pins"]]

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -205,6 +205,16 @@ def _feature_copy_text(name: str) -> str:
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
             return operator_copy.burn_label_checkpoint(label_text="20260420T040001Z-1")
+        case "recovery_expired_local_resume":
+            return operator_copy.recovery_expired_local_resume(
+                session_id="rs-20260420T040001Z-rebuild-1"
+            )
+        case "recovery_expired_needs_reapproval":
+            return operator_copy.recovery_expired_needs_reapproval(
+                session_id="rs-20260420T040001Z-rebuild-1",
+                affected=["docs"],
+                estimated_cost="12.34",
+            )
     raise AssertionError(f"unsupported operator copy reference: {name}")
 
 


### PR DESCRIPTION
## Summary
- split expired recovery into local-resume and reapproval-required accepted states
- route expired restores without local artifacts back through approval before another cloud request
- back local-artifact resume and no-local-artifact reapproval scenarios in the spec harness
- back prod expired-session setup and local artifact availability
- implement expired recovery local resume/reapproval behavior in `arc-disc recover`

## Tracking
- PM child #231 is closed
- Test child #305 is closed
- Test child #322 is closed
- Dev child #313 is closed

## Verification
- `make lint`
- `make unit args='tests/unit/test_acceptance_marker_enforcement.py'`\n- `make spec args='-k "test_expired_recovery_with_local_artifacts_resumes_without_another_approval or test_expired_recovery_without_local_artifacts_returns_to_approval"'`\n- `make prod args='-k "test_expired_recovery_with_local_artifacts_resumes_without_another_approval or test_expired_recovery_without_local_artifacts_returns_to_approval" -vv'`