### PR TITLE
Meta: Decide Riverhog API-unreachable operator states

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -101,6 +101,15 @@ def _error_detail(latest_error: str | None, *, prefix: str = "Last error") -> st
     return f" {prefix}: {truncate(latest_error, max_chars=120)}"
 
 
+def api_unreachable(*, api_url: str | None = None, latest_error: str | None = None) -> str:
+    target = f" at {api_url}" if api_url else ""
+    return (
+        f"Riverhog cannot reach the API{target}. "
+        "Check that the Riverhog service is running and that local configuration points to it."
+        f"{_error_detail(latest_error)}"
+    )
+
+
 # Shared guided flow copy
 
 

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -6,10 +6,15 @@ statecharts:
     states:
       scan_attention:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - guard: non_physical_attention_items
             target: attention_summary
           - target: no_attention
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       attention_summary:
         view: arc_home_attention
         transitions:
@@ -53,8 +58,13 @@ statecharts:
       prompt_collection_id:
         view: upload_prompt_collection_id
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - event: collection_id_entered
             target: prompt_source_path
+      api_unreachable:
+        view: api_unreachable
+        final: true
       prompt_source_path:
         view: upload_prompt_source_path
         transitions:
@@ -95,6 +105,8 @@ statecharts:
       choose_operation:
         view: arc_home_at_will_menu
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - event: search_hot_storage
             target: search_header
           - event: get_hot_file
@@ -108,6 +120,9 @@ statecharts:
           - event: release_pin
             target: release_done
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       search_header:
         view: hot_search_header
         transitions:
@@ -167,6 +182,8 @@ statecharts:
     states:
       choose_detail:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - event: show_collection
             target: collection_summary
           - event: plan_disc_work
@@ -176,6 +193,9 @@ statecharts:
           - event: show_cloud_backup_cost
             target: cloud_backup_report
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       collection_summary:
         view: collection_summary
         transitions:
@@ -222,6 +242,8 @@ statecharts:
     states:
       choose_copy_command:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - event: register_copy
             target: copy_registered
           - event: list_copies
@@ -235,6 +257,9 @@ statecharts:
           - event: mark_copy_damaged
             target: copy_marked_damaged
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       copy_registered:
         view: copy_registered
         final: true
@@ -259,6 +284,8 @@ statecharts:
     states:
       choose_check:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - event: check_setup
             target: doctor
           - event: check_recovery_costs
@@ -266,6 +293,9 @@ statecharts:
           - event: check_notifications
             target: notification_health_failed
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       doctor:
         transitions:
           - guard: setup_is_healthy
@@ -291,10 +321,15 @@ statecharts:
     states:
       scan_backlog:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - guard: physical_or_recovery_backlog
             target: attention_summary
           - target: no_attention
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       attention_summary:
         view: arc_disc_attention
         transitions:
@@ -342,6 +377,8 @@ statecharts:
     states:
       inspect_burn_work:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - guard: no_disc_work
             target: no_work
           - guard: unlabeled_verified_disc_available
@@ -351,6 +388,9 @@ statecharts:
           - guard: blank_disc_work_ready
             target: ready
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       no_work:
         view: burn_no_work
         final: true
@@ -415,6 +455,8 @@ statecharts:
     states:
       inspect_recovery:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - guard: approval_required
             target: approval_required
           - guard: recovery_requested
@@ -428,6 +470,9 @@ statecharts:
           - guard: recovery_cleanup_handoff_ready
             target: cleanup_handoff
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       approval_required:
         view: recovery_approval_required
         transitions:
@@ -467,8 +512,13 @@ statecharts:
     states:
       need_media:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - event: operator_inserts_disc
             target: insert_disc
+      api_unreachable:
+        view: api_unreachable
+        final: true
       insert_disc:
         view: hot_recovery_insert_disc
         transitions:
@@ -495,11 +545,16 @@ statecharts:
     states:
       fetch_requested:
         transitions:
+          - guard: api_unreachable
+            target: api_unreachable
           - guard: media_needed
             target: insert_disc
           - guard: upload_already_complete
             target: done
         type: choice
+      api_unreachable:
+        view: api_unreachable
+        final: true
       insert_disc:
         view: hot_recovery_insert_disc
         transitions:

--- a/docs/adr/0044-handle-api-unreachable-as-operator-preflight.md
+++ b/docs/adr/0044-handle-api-unreachable-as-operator-preflight.md
@@ -1,0 +1,15 @@
+# ADR-0044: Handle API Unreachability as Operator Preflight
+
+## Decision
+
+API-backed operator flows use a shared `api_unreachable` preflight state when the local CLI cannot reach the Riverhog API because the service is offline, refused, timed out, or otherwise unavailable.
+
+The state applies to `arc.home`, `arc.upload`, `arc.hot_storage`, `arc.collection_status`, `arc.copy_management`, `arc.maintenance`, `arc_disc.guided`, `arc_disc.burn`, `arc_disc.recovery`, `arc_disc.fetch`, and `arc_disc.hot_recovery`.
+
+Normal operator copy tells the user to check that the Riverhog API is running and that local configuration points to it. It must not expose raw transport exceptions as normal human guidance.
+
+Server-side notification payload generation is out of scope because it does not call the local operator API client.
+
+## Reason
+
+API availability is a cross-cutting boundary condition. A shared preflight state prevents each command from inventing different transport-failure wording or misclassifying API outages as domain failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_307: tracks issue #307 for backing API-unreachable-PM-scenarios",
+  "issue_312: tracks issue #312 for implementing API-unreachable operator states",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_307: tracks issue #307 for backing API-unreachable-PM-scenarios",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -203,6 +203,11 @@ def _notification_text(notification: operator_copy.ActionNeededNotification) -> 
 
 def render_operator_copy(reference: str) -> str:
     match reference:
+        case "api_unreachable":
+            return operator_copy.api_unreachable(
+                api_url="http://127.0.0.1:8000",
+                latest_error="connection refused",
+            )
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
         case "arc_home_attention":

--- a/src/arc_cli/api_preflight.py
+++ b/src/arc_cli/api_preflight.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import httpx
+
+from arc_cli.client import ApiClient
+from contracts.operator import copy as operator_copy
+
+
+class ApiUnreachable(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__(operator_copy.api_unreachable())
+        self.copy_text = operator_copy.api_unreachable()
+
+
+def check_api_reachable() -> None:
+    api = ApiClient()
+    try:
+        with httpx.Client(base_url=api.base_url, timeout=2.0) as client:
+            response = client.get("/healthz")
+    except httpx.HTTPError as exc:
+        raise ApiUnreachable() from exc
+    if response.is_success:
+        return
+    if response.status_code >= 500:
+        raise ApiUnreachable()

--- a/src/arc_cli/main.py
+++ b/src/arc_cli/main.py
@@ -7,6 +7,7 @@ from typing import Annotated, TypedDict
 
 import typer
 
+from arc_cli.api_preflight import ApiUnreachable, check_api_reachable
 from arc_cli.client import ApiClient
 from arc_cli.output import (
     emit,
@@ -24,7 +25,7 @@ from arc_cli.output import (
 )
 from arc_core.domain.errors import NotFound
 
-app = typer.Typer(help="arc archival control CLI")
+app = typer.Typer(help="arc archival control CLI", invoke_without_command=True)
 iso_app = typer.Typer(help="ISO operations")
 copy_app = typer.Typer(help="copy registration")
 app.add_typer(iso_app, name="iso")
@@ -44,6 +45,17 @@ class CollectionManifestEntry(TypedDict):
 
 def client() -> ApiClient:
     return ApiClient()
+
+
+@app.callback(invoke_without_command=True)
+def arc_app(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+    try:
+        check_api_reachable()
+    except ApiUnreachable as exc:
+        typer.echo(exc.copy_text)
+    raise typer.Exit(code=0)
 
 
 def _local_collection_manifest(root: Path) -> list[CollectionManifestEntry]:

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -15,16 +15,24 @@ from typing import Annotated, Any
 
 import typer
 
+from arc_cli.api_preflight import ApiUnreachable, check_api_reachable
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
 
-app = typer.Typer(help="arc optical recovery CLI")
+app = typer.Typer(help="arc optical recovery CLI", invoke_without_command=True)
 
 
-@app.callback()
-def arc_disc_app() -> None:
-    """Keep the CLI in group mode so `arc-disc fetch ...` stays canonical."""
+@app.callback(invoke_without_command=True)
+def arc_disc_app(ctx: typer.Context) -> None:
+    """Keep subcommands canonical while allowing guided no-argument checks."""
+    if ctx.invoked_subcommand is not None:
+        return
+    try:
+        check_api_reachable()
+    except ApiUnreachable as exc:
+        typer.echo(exc.copy_text)
+    raise typer.Exit(code=0)
 
 
 _DISC_IO_CHUNK_BYTES = 1024 * 1024

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,6 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @contract_gap @issue_312
     Scenario: arc reports API unreachability as accepted operator copy
       Given statechart "arc.home" state "api_unreachable" is the accepted operator contract
       And the Riverhog API is unreachable

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,7 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @todo @issue_307
+    @contract_gap @issue_312
     Scenario: arc reports API unreachability as accepted operator copy
       Given statechart "arc.home" state "api_unreachable" is the accepted operator contract
       And the Riverhog API is unreachable

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,6 +108,16 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
+    @todo @issue_246
+    Scenario: arc reports API unreachability as accepted operator copy
+      Given statechart "arc.home" state "api_unreachable" is the accepted operator contract
+      And the Riverhog API is unreachable
+      When the operator runs 'arc'
+      Then stdout includes operator copy "api_unreachable"
+      And stdout mentions "Riverhog cannot reach the API"
+      And stdout mentions "Riverhog service is running"
+      And stdout does not mention "httpx"
+
     @contract_gap @issue_209
     Scenario: arc opens the operator home when no attention is needed
       Given statechart "arc.home" state "no_attention" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,7 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @todo @issue_246
+    @todo @issue_307
     Scenario: arc reports API unreachability as accepted operator copy
       Given statechart "arc.home" state "api_unreachable" is the accepted operator contract
       And the Riverhog API is unreachable

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,6 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @contract_gap @issue_312
     Scenario: arc-disc reports API unreachability as accepted operator copy
       Given statechart "arc_disc.guided" state "api_unreachable" is the accepted operator contract
       And the Riverhog API is unreachable

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_307
+    @contract_gap @issue_312
     Scenario: arc-disc reports API unreachability as accepted operator copy
       Given statechart "arc_disc.guided" state "api_unreachable" is the accepted operator contract
       And the Riverhog API is unreachable

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_246
+    @todo @issue_307
     Scenario: arc-disc reports API unreachability as accepted operator copy
       Given statechart "arc_disc.guided" state "api_unreachable" is the accepted operator contract
       And the Riverhog API is unreachable

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,6 +4,16 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
+    @todo @issue_246
+    Scenario: arc-disc reports API unreachability as accepted operator copy
+      Given statechart "arc_disc.guided" state "api_unreachable" is the accepted operator contract
+      And the Riverhog API is unreachable
+      When the operator runs 'arc-disc'
+      Then stdout includes operator copy "api_unreachable"
+      And stdout mentions "Riverhog cannot reach the API"
+      And stdout mentions "local configuration"
+      And stdout does not mention "httpx"
+
     @contract_gap @issue_208
     Scenario: arc-disc resumes unfinished local disc work before choosing new work
       Given statechart "arc_disc.guided" state "unfinished_local_disc" is the accepted operator contract

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -541,6 +541,7 @@ class AcceptanceState:
     next_fetch_number: int = 0
     operator_arc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
     operator_disc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
+    operator_api_unreachable: bool = False
     operator_blank_disc_work_available: bool = False
     operator_label_confirmation_location: str | None = None
     operator_collection_fully_protected: bool = False
@@ -4337,6 +4338,10 @@ class AcceptanceSystem:
         with self.state.lock:
             self.state.operator_arc_items.clear()
 
+    def set_operator_api_unreachable(self) -> None:
+        with self.state.lock:
+            self.state.operator_api_unreachable = True
+
     def add_operator_cloud_backup_failure(
         self,
         collection_id: str,
@@ -4459,6 +4464,22 @@ class AcceptanceSystem:
         if not args:
             with self.state.lock:
                 items = sorted(self.state.operator_arc_items, key=lambda item: item.priority)
+                api_unreachable = self.state.operator_api_unreachable
+            if api_unreachable:
+                stdout = operator_copy.api_unreachable()
+                return _operator_completed_process(
+                    ["arc"],
+                    returncode=1,
+                    stdout=stdout,
+                    decisions=[_operator_decision("arc.home", "api_unreachable")],
+                    views=[
+                        _operator_view(
+                            "arc.home",
+                            "api_unreachable",
+                            text=stdout,
+                        )
+                    ],
+                )
             if not items:
                 stdout = operator_copy.arc_home_no_attention()
                 return _operator_completed_process(
@@ -4577,6 +4598,22 @@ class AcceptanceSystem:
             items = sorted(self.state.operator_disc_items, key=lambda item: item.priority)
             blank_disc_work = self.state.operator_blank_disc_work_available
             label_location = self.state.operator_label_confirmation_location
+            api_unreachable = self.state.operator_api_unreachable
+        if api_unreachable:
+            stdout = operator_copy.api_unreachable()
+            return _operator_completed_process(
+                ["arc-disc"],
+                returncode=1,
+                stdout=stdout,
+                decisions=[_operator_decision("arc_disc.guided", "api_unreachable")],
+                views=[
+                    _operator_view(
+                        "arc_disc.guided",
+                        "api_unreachable",
+                        text=stdout,
+                    )
+                ],
+            )
         if items:
             stdout = operator_copy.arc_disc_attention(items)
             decisions: list[OperatorDecision] = []

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -184,6 +184,30 @@ def _actual_operator_views(
     return (*_command_operator_views(context), *context.actual_operator_views)
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _assert_actual_operator_view_matches_copy_ref(
     context: AcceptanceScenarioContext,
     name: str,
@@ -4506,6 +4530,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4517,6 +4542,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4528,6 +4554,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -261,6 +261,8 @@ def _guided_item_text(
 
 def _operator_copy_text(name: str) -> str:
     match name:
+        case "api_unreachable":
+            return operator_copy.api_unreachable()
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
         case "arc_item_cloud_backup_failed":
@@ -1025,6 +1027,13 @@ def given_archive_has_no_non_physical_attention_items(
     acceptance_system: AcceptanceSystem,
 ) -> None:
     acceptance_system.clear_operator_arc_attention()
+
+
+@given("the Riverhog API is unreachable")
+def given_riverhog_api_is_unreachable(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_api_unreachable()
 
 
 @given(parsers.parse('collection "{collection_id}" has failed cloud backup after retries'))

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -877,6 +877,9 @@ class ProductionSystem:
                 check=False,
             )
 
+    def set_operator_api_unreachable(self) -> None:
+        self.base_url = "http://127.0.0.1:9"
+
     def delete_hot_backing_file(self, target: str) -> None:
         selected = self.state.selected_files(target)
         if len(selected) != 1:

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -772,6 +772,7 @@ class ProductionSystem:
         with time_block("fixture.acceptance_system.reset"):
             self._clear_fixture_path()
             self.server.reset()
+            self.base_url = self.server.base_url
 
     def request(
         self,

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -102,6 +102,11 @@ def _guided_item_text(
 
 def _feature_copy_text(name: str) -> str:
     match name:
+        case "api_unreachable":
+            return operator_copy.api_unreachable(
+                api_url="http://127.0.0.1:8000",
+                latest_error="connection refused",
+            )
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
         case "arc_item_cloud_backup_failed":

--- a/tests/unit/test_statechart_catalog.py
+++ b/tests/unit/test_statechart_catalog.py
@@ -24,6 +24,7 @@ def test_statechart_catalog_resolves_states_views_transitions_and_handoffs() -> 
         "pin_waiting_for_disc"
     )
     assert catalog.transition_targets("arc.hot_storage", "choose_operation") == (
+        "api_unreachable",
         "search_header",
         "get_starting",
         "pin_requested",


### PR DESCRIPTION
## Summary
- add ADR-0044 for API-unreachable as shared operator preflight
- add api_unreachable state and copy across API-backed operator statecharts
- back arc and arc-disc API-unreachable PM scenarios in the spec harness
- back prod API-unreachable setup by pointing real CLI subprocesses at an unreachable API URL
- implement no-argument API reachability preflight for `arc` and `arc-disc`

## Tracking
- PM child #246 is closed
- Test child #307 is closed
- Test child #323 is closed
- Dev child #312 is closed

## Verification
- `make lint`
- `make unit args='tests/unit/test_acceptance_marker_enforcement.py'`\n- `make spec args='-k "test_arc_reports_api_unreachability_as_accepted_operator_copy or test_arcdisc_reports_api_unreachability_as_accepted_operator_copy"'`\n- `make prod args='-k "test_arc_reports_api_unreachability_as_accepted_operator_copy or test_arcdisc_reports_api_unreachability_as_accepted_operator_copy" -vv'`