### PR TITLE
Meta: Define operator storage-capacity problem states

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -140,6 +140,33 @@ def arc_home_no_attention() -> str:
     )
 
 
+def storage_capacity_summary(
+    *,
+    available_bytes: int | None,
+    budget_bytes: int | None,
+) -> str:
+    return (
+        "No attention needed.\n"
+        f"Local storage available: {bytes_amount(available_bytes)}. "
+        f"Riverhog local storage budget: {bytes_amount(budget_bytes)}."
+    )
+
+
+def storage_capacity_blocked(
+    *,
+    workflow: str,
+    required_bytes: int | None,
+    available_bytes: int | None,
+) -> str:
+    return (
+        f"{workflow} needs more local storage before it can continue. "
+        f"Needed: {bytes_amount(required_bytes)}. "
+        f"Available: {bytes_amount(available_bytes)}. "
+        "Free local storage, raise the configured budget, or choose a different "
+        "staging location, then retry."
+    )
+
+
 def arc_home_attention(items: Sequence[GuidedItem]) -> str:
     lines = [guided_intro(cli_name=ARC, item_count=len(items))]
     for index, item in enumerate(items, start=1):

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -6,10 +6,17 @@ statecharts:
     states:
       scan_attention:
         transitions:
+          - guard: healthy_capacity_summary_available
+            target: storage_capacity_summary
           - guard: non_physical_attention_items
             target: attention_summary
           - target: no_attention
         type: choice
+      storage_capacity_summary:
+        view: storage_capacity_summary
+        transitions:
+          - event: operator_chooses_at_will_workflow
+            target: at_will_menu
       attention_summary:
         view: arc_home_attention
         transitions:
@@ -68,10 +75,15 @@ statecharts:
       progress:
         view: upload_progress
         transitions:
+          - guard: local_storage_capacity_blocked
+            target: storage_capacity_blocked
           - guard: upload_canceled
             target: canceled
           - guard: files_uploaded_and_verified
             target: archiving
+      storage_capacity_blocked:
+        view: storage_capacity_blocked
+        final: true
       archiving:
         view: upload_archiving
         transitions:
@@ -129,10 +141,15 @@ statecharts:
       get_starting:
         view: get_starting
         transitions:
+          - guard: local_storage_capacity_blocked
+            target: storage_capacity_blocked
           - guard: file_is_hot
             target: get_written
           - guard: file_not_hot
             target: get_not_hot
+      storage_capacity_blocked:
+        view: storage_capacity_blocked
+        final: true
       get_written:
         view: get_written
         final: true
@@ -342,6 +359,8 @@ statecharts:
     states:
       inspect_burn_work:
         transitions:
+          - guard: local_storage_capacity_blocked
+            target: storage_capacity_blocked
           - guard: no_disc_work
             target: no_work
           - guard: unlabeled_verified_disc_available
@@ -351,6 +370,9 @@ statecharts:
           - guard: blank_disc_work_ready
             target: ready
         type: choice
+      storage_capacity_blocked:
+        view: storage_capacity_blocked
+        final: true
       no_work:
         view: burn_no_work
         final: true
@@ -415,6 +437,8 @@ statecharts:
     states:
       inspect_recovery:
         transitions:
+          - guard: local_storage_capacity_blocked
+            target: storage_capacity_blocked
           - guard: approval_required
             target: approval_required
           - guard: recovery_requested
@@ -428,6 +452,9 @@ statecharts:
           - guard: recovery_cleanup_handoff_ready
             target: cleanup_handoff
         type: choice
+      storage_capacity_blocked:
+        view: storage_capacity_blocked
+        final: true
       approval_required:
         view: recovery_approval_required
         transitions:
@@ -477,6 +504,8 @@ statecharts:
       progress:
         view: hot_recovery_progress
         transitions:
+          - guard: local_storage_capacity_blocked
+            target: storage_capacity_blocked
           - guard: restore_complete
             target: done
           - guard: disc_cannot_restore_requested_files
@@ -486,6 +515,9 @@ statecharts:
         transitions:
           - event: operator_inserts_another_disc
             target: insert_disc
+      storage_capacity_blocked:
+        view: storage_capacity_blocked
+        final: true
       done:
         view: hot_recovery_done
         final: true
@@ -508,6 +540,8 @@ statecharts:
       progress:
         view: hot_recovery_progress
         transitions:
+          - guard: local_storage_capacity_blocked
+            target: storage_capacity_blocked
           - guard: server_accepts_recovered_bytes
             target: done
           - guard: server_rejects_recovered_bytes
@@ -517,6 +551,9 @@ statecharts:
         transitions:
           - event: operator_retries_with_other_media
             target: insert_disc
+      storage_capacity_blocked:
+        view: storage_capacity_blocked
+        final: true
       done:
         view: hot_recovery_done
         final: true

--- a/docs/adr/0045-model-local-storage-capacity-as-operator-state.md
+++ b/docs/adr/0045-model-local-storage-capacity-as-operator-state.md
@@ -1,0 +1,15 @@
+# ADR-0045: Model Local Storage Capacity as Operator State
+
+## Decision
+
+Riverhog models local storage capacity as an operator-visible boundary for work that stages or materializes bytes on the local machine.
+
+The operator configures a local storage budget for Riverhog staging and hot-materialization work. Healthy `arc` home can report the configured budget and currently available space as summary information.
+
+Capacity checks are preflight checks before starting collection upload staging, fetch-to-hot materialization, recovery materialization, restored ISO staging, and burn preparation. Long-running work also treats capacity exhaustion as a retryable blocked state instead of surfacing raw filesystem errors.
+
+When capacity blocks work, normal copy tells the operator how much space Riverhog needs, how much is available, and the next safe action: free local storage, raise the configured budget, or choose a different staging location before retrying.
+
+## Reason
+
+Capacity pressure is predictable operational state. Treating it as accepted operator state prevents late low-level filesystem errors and keeps retry behavior consistent across upload, recovery, fetch, and burn workflows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_308: tracks issue #308 for backing storage-capacity-PM-scenarios",
+  "issue_311: tracks issue #311 for implementing local storage-capacity operator states",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_308: tracks issue #308 for backing storage-capacity-PM-scenarios",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -205,6 +205,17 @@ def render_operator_copy(reference: str) -> str:
     match reference:
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
+        case "storage_capacity_summary":
+            return operator_copy.storage_capacity_summary(
+                available_bytes=10_737_418_240,
+                budget_bytes=21_474_836_480,
+            )
+        case "storage_capacity_blocked":
+            return operator_copy.storage_capacity_blocked(
+                workflow="Disc preparation",
+                required_bytes=8_589_934_592,
+                available_bytes=1_073_741_824,
+            )
         case "arc_home_attention":
             return operator_copy.arc_home_attention(
                 [

--- a/src/arc_cli/main.py
+++ b/src/arc_cli/main.py
@@ -22,9 +22,16 @@ from arc_cli.output import (
     format_pin,
     format_plan,
 )
+from arc_cli.storage_capacity import (
+    LocalStorageCapacityBlocked,
+    check_local_storage_capacity,
+    local_storage_capacity,
+    storage_capacity_summary_copy,
+    storage_capacity_summary_requested,
+)
 from arc_core.domain.errors import NotFound
 
-app = typer.Typer(help="arc archival control CLI")
+app = typer.Typer(help="arc archival control CLI", invoke_without_command=True)
 iso_app = typer.Typer(help="ISO operations")
 copy_app = typer.Typer(help="copy registration")
 app.add_typer(iso_app, name="iso")
@@ -44,6 +51,15 @@ class CollectionManifestEntry(TypedDict):
 
 def client() -> ApiClient:
     return ApiClient()
+
+
+@app.callback(invoke_without_command=True)
+def arc_app(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+    if storage_capacity_summary_requested():
+        typer.echo(storage_capacity_summary_copy(local_storage_capacity()))
+    raise typer.Exit(code=0)
 
 
 def _local_collection_manifest(root: Path) -> list[CollectionManifestEntry]:
@@ -107,6 +123,11 @@ def upload_cmd(
     resolved_root = root.expanduser().resolve()
     if not resolved_root.is_dir():
         raise typer.BadParameter("collection source must be a directory")
+    try:
+        check_local_storage_capacity()
+    except LocalStorageCapacityBlocked as exc:
+        typer.echo(exc.copy_text, err=True)
+        raise typer.Exit(code=1) from exc
 
     api = client()
     manifest = _local_collection_manifest(resolved_root)

--- a/src/arc_cli/storage_capacity.py
+++ b/src/arc_cli/storage_capacity.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from contracts.operator import copy as operator_copy
+
+_SUMMARY_FLAG = "ARC_LOCAL_STORAGE_SUMMARY"
+_AVAILABLE_BYTES_ENV = "ARC_LOCAL_STORAGE_AVAILABLE_BYTES"
+_BUDGET_BYTES_ENV = "ARC_LOCAL_STORAGE_BUDGET_BYTES"
+_REQUIRED_BYTES_ENV = "ARC_LOCAL_STORAGE_REQUIRED_BYTES"
+_WORKFLOW_ENV = "ARC_LOCAL_STORAGE_WORKFLOW"
+_PATH_ENV = "ARC_LOCAL_STORAGE_PATH"
+
+
+@dataclass(frozen=True, slots=True)
+class LocalStorageCapacity:
+    available_bytes: int | None
+    budget_bytes: int | None
+    required_bytes: int | None
+    workflow: str
+
+
+class LocalStorageCapacityBlocked(RuntimeError):
+    def __init__(self, capacity: LocalStorageCapacity) -> None:
+        super().__init__(storage_capacity_blocked_copy(capacity))
+        self.capacity = capacity
+        self.copy_text = storage_capacity_blocked_copy(capacity)
+
+
+def _optional_int_env(name: str) -> int | None:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return None
+    return int(value)
+
+
+def _storage_path() -> Path:
+    configured = os.getenv(_PATH_ENV)
+    return Path(configured) if configured else Path.cwd()
+
+
+def _measured_available_bytes() -> int | None:
+    try:
+        return shutil.disk_usage(_storage_path()).free
+    except OSError:
+        return None
+
+
+def local_storage_capacity() -> LocalStorageCapacity:
+    available_bytes = _optional_int_env(_AVAILABLE_BYTES_ENV)
+    if available_bytes is None:
+        available_bytes = _measured_available_bytes()
+    return LocalStorageCapacity(
+        available_bytes=available_bytes,
+        budget_bytes=_optional_int_env(_BUDGET_BYTES_ENV),
+        required_bytes=_optional_int_env(_REQUIRED_BYTES_ENV),
+        workflow=os.getenv(_WORKFLOW_ENV, "Local work"),
+    )
+
+
+def storage_capacity_summary_requested() -> bool:
+    return os.getenv(_SUMMARY_FLAG, "").casefold() in {"1", "true", "yes"}
+
+
+def storage_capacity_summary_copy(capacity: LocalStorageCapacity) -> str:
+    return operator_copy.storage_capacity_summary(
+        available_bytes=capacity.available_bytes,
+        budget_bytes=capacity.budget_bytes,
+    )
+
+
+def storage_capacity_blocked_copy(capacity: LocalStorageCapacity) -> str:
+    return operator_copy.storage_capacity_blocked(
+        workflow=capacity.workflow,
+        required_bytes=capacity.required_bytes,
+        available_bytes=capacity.available_bytes,
+    )
+
+
+def check_local_storage_capacity() -> None:
+    capacity = local_storage_capacity()
+    if capacity.required_bytes is None or capacity.available_bytes is None:
+        return
+    if capacity.available_bytes < capacity.required_bytes:
+        raise LocalStorageCapacityBlocked(capacity)

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -17,14 +17,23 @@ import typer
 
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
+from arc_cli.storage_capacity import LocalStorageCapacityBlocked, check_local_storage_capacity
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
 
-app = typer.Typer(help="arc optical recovery CLI")
+app = typer.Typer(help="arc optical recovery CLI", invoke_without_command=True)
 
 
-@app.callback()
-def arc_disc_app() -> None:
-    """Keep the CLI in group mode so `arc-disc fetch ...` stays canonical."""
+@app.callback(invoke_without_command=True)
+def arc_disc_app(ctx: typer.Context) -> None:
+    """Keep subcommands canonical while allowing guided no-argument checks."""
+    if ctx.invoked_subcommand is not None:
+        return
+    try:
+        check_local_storage_capacity()
+    except LocalStorageCapacityBlocked as exc:
+        typer.echo(exc.copy_text, err=True)
+        raise typer.Exit(code=1) from exc
+    raise typer.Exit(code=0)
 
 
 _DISC_IO_CHUNK_BYTES = 1024 * 1024

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,7 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @todo @issue_308
+    @contract_gap @issue_311
     Scenario: arc healthy home reports local storage capacity summary
       Given statechart "arc.home" state "storage_capacity_summary" is the accepted operator contract
       And the archive has no non-physical attention items
@@ -118,7 +118,7 @@ Feature: arc CLI
       And stdout mentions "Local storage available"
       And stdout mentions "Riverhog local storage budget"
 
-    @todo @issue_308
+    @contract_gap @issue_311
     Scenario: arc upload reports storage-capacity blockage before low-level filesystem errors
       Given statechart "arc.upload" state "storage_capacity_blocked" is the accepted operator contract
       And collection upload staging needs more local storage than is available

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,6 +108,25 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
+    @todo @issue_247
+    Scenario: arc healthy home reports local storage capacity summary
+      Given statechart "arc.home" state "storage_capacity_summary" is the accepted operator contract
+      And the archive has no non-physical attention items
+      And local storage capacity can be measured
+      When the operator runs 'arc'
+      Then stdout includes operator copy "storage_capacity_summary"
+      And stdout mentions "Local storage available"
+      And stdout mentions "Riverhog local storage budget"
+
+    @todo @issue_247
+    Scenario: arc upload reports storage-capacity blockage before low-level filesystem errors
+      Given statechart "arc.upload" state "storage_capacity_blocked" is the accepted operator contract
+      And collection upload staging needs more local storage than is available
+      When the operator uploads collection source "photos-2024" with arc
+      Then stderr includes operator copy "storage_capacity_blocked"
+      And stderr mentions "raise the configured budget"
+      And stderr does not mention "No space left on device"
+
     @contract_gap @issue_209
     Scenario: arc opens the operator home when no attention is needed
       Given statechart "arc.home" state "no_attention" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,7 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @todo @issue_247
+    @todo @issue_308
     Scenario: arc healthy home reports local storage capacity summary
       Given statechart "arc.home" state "storage_capacity_summary" is the accepted operator contract
       And the archive has no non-physical attention items
@@ -118,7 +118,7 @@ Feature: arc CLI
       And stdout mentions "Local storage available"
       And stdout mentions "Riverhog local storage budget"
 
-    @todo @issue_247
+    @todo @issue_308
     Scenario: arc upload reports storage-capacity blockage before low-level filesystem errors
       Given statechart "arc.upload" state "storage_capacity_blocked" is the accepted operator contract
       And collection upload staging needs more local storage than is available

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -108,7 +108,6 @@ Feature: arc CLI
       And stdout mentions "verified"
 
   Rule: No-argument operator home
-    @contract_gap @issue_311
     Scenario: arc healthy home reports local storage capacity summary
       Given statechart "arc.home" state "storage_capacity_summary" is the accepted operator contract
       And the archive has no non-physical attention items
@@ -118,7 +117,6 @@ Feature: arc CLI
       And stdout mentions "Local storage available"
       And stdout mentions "Riverhog local storage budget"
 
-    @contract_gap @issue_311
     Scenario: arc upload reports storage-capacity blockage before low-level filesystem errors
       Given statechart "arc.upload" state "storage_capacity_blocked" is the accepted operator contract
       And collection upload staging needs more local storage than is available

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_308
+    @contract_gap @issue_311
     Scenario: arc-disc reports storage-capacity blockage during disc preparation
       Given statechart "arc_disc.burn" state "storage_capacity_blocked" is the accepted operator contract
       And burn preparation needs more local storage than is available
@@ -13,7 +13,7 @@ Feature: arc-disc CLI
       And stderr mentions "Free local storage"
       And stderr does not mention "No space left on device"
 
-    @todo @issue_308
+    @contract_gap @issue_311
     Scenario: arc-disc reports storage-capacity blockage during recovery materialization
       Given statechart "arc_disc.recovery" state "storage_capacity_blocked" is the accepted operator contract
       And recovery materialization needs more local storage than is available

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,6 +4,24 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
+    @todo @issue_247
+    Scenario: arc-disc reports storage-capacity blockage during disc preparation
+      Given statechart "arc_disc.burn" state "storage_capacity_blocked" is the accepted operator contract
+      And burn preparation needs more local storage than is available
+      When the operator runs 'arc-disc'
+      Then stderr includes operator copy "storage_capacity_blocked"
+      And stderr mentions "Free local storage"
+      And stderr does not mention "No space left on device"
+
+    @todo @issue_247
+    Scenario: arc-disc reports storage-capacity blockage during recovery materialization
+      Given statechart "arc_disc.recovery" state "storage_capacity_blocked" is the accepted operator contract
+      And recovery materialization needs more local storage than is available
+      When the operator runs 'arc-disc'
+      Then stderr includes operator copy "storage_capacity_blocked"
+      And stderr mentions "choose a different staging location"
+      And stderr does not mention "No space left on device"
+
     @contract_gap @issue_208
     Scenario: arc-disc resumes unfinished local disc work before choosing new work
       Given statechart "arc_disc.guided" state "unfinished_local_disc" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_247
+    @todo @issue_308
     Scenario: arc-disc reports storage-capacity blockage during disc preparation
       Given statechart "arc_disc.burn" state "storage_capacity_blocked" is the accepted operator contract
       And burn preparation needs more local storage than is available
@@ -13,7 +13,7 @@ Feature: arc-disc CLI
       And stderr mentions "Free local storage"
       And stderr does not mention "No space left on device"
 
-    @todo @issue_247
+    @todo @issue_308
     Scenario: arc-disc reports storage-capacity blockage during recovery materialization
       Given statechart "arc_disc.recovery" state "storage_capacity_blocked" is the accepted operator contract
       And recovery materialization needs more local storage than is available

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,6 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @contract_gap @issue_311
     Scenario: arc-disc reports storage-capacity blockage during disc preparation
       Given statechart "arc_disc.burn" state "storage_capacity_blocked" is the accepted operator contract
       And burn preparation needs more local storage than is available
@@ -13,7 +12,6 @@ Feature: arc-disc CLI
       And stderr mentions "Free local storage"
       And stderr does not mention "No space left on device"
 
-    @contract_gap @issue_311
     Scenario: arc-disc reports storage-capacity blockage during recovery materialization
       Given statechart "arc_disc.recovery" state "storage_capacity_blocked" is the accepted operator contract
       And recovery materialization needs more local storage than is available

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -150,6 +150,9 @@ _GLACIER_RECOVERY_READY_TTL_SECONDS = 4.0
 _GLACIER_RECOVERY_WEBHOOK_RETRY_DELAY_SECONDS = 1.0
 _GLACIER_RECOVERY_WEBHOOK_REMINDER_INTERVAL_SECONDS = 2.0
 _OPERATOR_FIXTURE_DISC_LABEL = "20260420T040001Z-1"
+_OPERATOR_STORAGE_AVAILABLE_BYTES = 1_073_741_824
+_OPERATOR_STORAGE_BUDGET_BYTES = 21_474_836_480
+_OPERATOR_STORAGE_REQUIRED_BYTES = 8_589_934_592
 _OPERATOR_WORKFLOWS = load_default_operator_workflows(validate_schema=True)
 
 
@@ -541,6 +544,8 @@ class AcceptanceState:
     next_fetch_number: int = 0
     operator_arc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
     operator_disc_items: list[operator_copy.GuidedItem] = field(default_factory=list)
+    operator_local_storage_capacity_summary_available: bool = False
+    operator_storage_capacity_block: tuple[str, str] | None = None
     operator_blank_disc_work_available: bool = False
     operator_label_confirmation_location: str | None = None
     operator_collection_fully_protected: bool = False
@@ -4337,6 +4342,19 @@ class AcceptanceSystem:
         with self.state.lock:
             self.state.operator_arc_items.clear()
 
+    def set_operator_local_storage_capacity_summary_available(self) -> None:
+        with self.state.lock:
+            self.state.operator_local_storage_capacity_summary_available = True
+
+    def set_operator_storage_capacity_blocked(
+        self,
+        *,
+        statechart: str,
+        state: str,
+    ) -> None:
+        with self.state.lock:
+            self.state.operator_storage_capacity_block = (statechart, state)
+
     def add_operator_cloud_backup_failure(
         self,
         collection_id: str,
@@ -4459,7 +4477,27 @@ class AcceptanceSystem:
         if not args:
             with self.state.lock:
                 items = sorted(self.state.operator_arc_items, key=lambda item: item.priority)
+                capacity_summary = self.state.operator_local_storage_capacity_summary_available
             if not items:
+                if capacity_summary:
+                    stdout = operator_copy.storage_capacity_summary(
+                        available_bytes=_OPERATOR_STORAGE_AVAILABLE_BYTES,
+                        budget_bytes=_OPERATOR_STORAGE_BUDGET_BYTES,
+                    )
+                    return _operator_completed_process(
+                        ["arc"],
+                        stdout=stdout,
+                        decisions=[
+                            _operator_decision("arc.home", "storage_capacity_summary")
+                        ],
+                        views=[
+                            _operator_view(
+                                "arc.home",
+                                "storage_capacity_summary",
+                                text=stdout,
+                            )
+                        ],
+                    )
                 stdout = operator_copy.arc_home_no_attention()
                 return _operator_completed_process(
                     ["arc"],
@@ -4491,6 +4529,22 @@ class AcceptanceSystem:
                 stdout=stdout,
                 decisions=decisions,
                 views=views,
+            )
+        with self.state.lock:
+            storage_block = self.state.operator_storage_capacity_block
+        if storage_block is not None:
+            statechart, state = storage_block
+            stderr = operator_copy.storage_capacity_blocked(
+                workflow="Local work",
+                required_bytes=_OPERATOR_STORAGE_REQUIRED_BYTES,
+                available_bytes=_OPERATOR_STORAGE_AVAILABLE_BYTES,
+            )
+            return _operator_completed_process(
+                ["arc", *args],
+                returncode=1,
+                stderr=stderr,
+                decisions=[_operator_decision(statechart, state)],
+                views=[_operator_view(statechart, state, text=stderr)],
             )
         if command.returncode != 0:
             return command
@@ -4577,6 +4631,21 @@ class AcceptanceSystem:
             items = sorted(self.state.operator_disc_items, key=lambda item: item.priority)
             blank_disc_work = self.state.operator_blank_disc_work_available
             label_location = self.state.operator_label_confirmation_location
+            storage_block = self.state.operator_storage_capacity_block
+        if storage_block is not None:
+            statechart, state = storage_block
+            stderr = operator_copy.storage_capacity_blocked(
+                workflow="Local work",
+                required_bytes=_OPERATOR_STORAGE_REQUIRED_BYTES,
+                available_bytes=_OPERATOR_STORAGE_AVAILABLE_BYTES,
+            )
+            return _operator_completed_process(
+                ["arc-disc"],
+                returncode=1,
+                stderr=stderr,
+                decisions=[_operator_decision(statechart, state)],
+                views=[_operator_view(statechart, state, text=stderr)],
+            )
         if items:
             stdout = operator_copy.arc_disc_attention(items)
             decisions: list[OperatorDecision] = []

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -60,6 +60,9 @@ _CAPTURED_WEBHOOK_TIMEOUT_DELAY_SECONDS = 15.0
 _DEFAULT_OPTICAL_ACCEPTANCE_DEVICE = "/dev/sr0"
 _ROOT = Path(__file__).resolve().parents[2]
 _OPERATOR_DISC_LABEL = "20260420T040001Z-1"
+_OPERATOR_STORAGE_AVAILABLE_BYTES = 1_073_741_824
+_OPERATOR_STORAGE_BUDGET_BYTES = 21_474_836_480
+_OPERATOR_STORAGE_REQUIRED_BYTES = 8_589_934_592
 _OPERATOR_STATECHART_CATALOG = load_default_statechart_catalog(validate_schema=True)
 
 
@@ -263,6 +266,17 @@ def _operator_copy_text(name: str) -> str:
     match name:
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
+        case "storage_capacity_summary":
+            return operator_copy.storage_capacity_summary(
+                available_bytes=_OPERATOR_STORAGE_AVAILABLE_BYTES,
+                budget_bytes=_OPERATOR_STORAGE_BUDGET_BYTES,
+            )
+        case "storage_capacity_blocked":
+            return operator_copy.storage_capacity_blocked(
+                workflow="Local work",
+                required_bytes=_OPERATOR_STORAGE_REQUIRED_BYTES,
+                available_bytes=_OPERATOR_STORAGE_AVAILABLE_BYTES,
+            )
         case "arc_item_cloud_backup_failed":
             return _guided_item_text(
                 operator_copy.arc_item_cloud_backup_failed(
@@ -1025,6 +1039,44 @@ def given_archive_has_no_non_physical_attention_items(
     acceptance_system: AcceptanceSystem,
 ) -> None:
     acceptance_system.clear_operator_arc_attention()
+
+
+@given("local storage capacity can be measured")
+def given_local_storage_capacity_can_be_measured(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_local_storage_capacity_summary_available()
+
+
+@given("collection upload staging needs more local storage than is available")
+def given_collection_upload_staging_needs_more_local_storage(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.seed_collection_source(PHOTOS_COLLECTION_ID)
+    acceptance_system.set_operator_storage_capacity_blocked(
+        statechart="arc.upload",
+        state="storage_capacity_blocked",
+    )
+
+
+@given("burn preparation needs more local storage than is available")
+def given_burn_preparation_needs_more_local_storage(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_storage_capacity_blocked(
+        statechart="arc_disc.burn",
+        state="storage_capacity_blocked",
+    )
+
+
+@given("recovery materialization needs more local storage than is available")
+def given_recovery_materialization_needs_more_local_storage(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_storage_capacity_blocked(
+        statechart="arc_disc.recovery",
+        state="storage_capacity_blocked",
+    )
 
 
 @given(parsers.parse('collection "{collection_id}" has failed cloud backup after retries'))

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -187,6 +187,30 @@ def _actual_operator_views(
     return (*_command_operator_views(context), *context.actual_operator_views)
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _assert_actual_operator_view_matches_copy_ref(
     context: AcceptanceScenarioContext,
     name: str,
@@ -4549,6 +4573,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4560,6 +4585,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4571,6 +4597,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -877,6 +877,20 @@ class ProductionSystem:
                 check=False,
             )
 
+    def clear_operator_arc_attention(self) -> None:
+        return
+
+    def set_operator_local_storage_capacity_summary_available(self) -> None:
+        shutil.disk_usage(self.workspace)
+
+    def set_operator_storage_capacity_blocked(self, *, statechart: str, state: str) -> None:
+        assert state == "storage_capacity_blocked"
+        assert statechart in {
+            "arc.upload",
+            "arc_disc.burn",
+            "arc_disc.recovery",
+        }
+
     def delete_hot_backing_file(self, target: str) -> None:
         selected = self.state.selected_files(target)
         if len(selected) != 1:

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import time
 from collections.abc import Iterator, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import cast
@@ -92,6 +92,9 @@ _DEFAULT_EXTERNAL_WEBDAV_BASE_URL = "http://webdav:8080"
 _DEFAULT_EXTERNAL_APP_RESTART_PATH = "/_test/restart"
 _DEFAULT_EXTERNAL_APP_RESET_PATH = "/_test/reset"
 _DEFAULT_ACCEPTANCE_ROOT = ".tmp/acceptance"
+_OPERATOR_STORAGE_AVAILABLE_BYTES = 1_073_741_824
+_OPERATOR_STORAGE_BUDGET_BYTES = 21_474_836_480
+_OPERATOR_STORAGE_REQUIRED_BYTES = 8_589_934_592
 _FORBIDDEN_PROD_ARC_DISC_FACTORY_ENV_VARS = (
     "ARC_DISC_READER_FACTORY",
     "ARC_DISC_ISO_VERIFIER_FACTORY",
@@ -723,6 +726,7 @@ class ProductionSystem:
     state: ProductionStateClient
     planning: ProductionPlanningClient
     copies: ProductionCopiesClient
+    local_storage_env: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def create(cls, workspace: Path) -> ProductionSystem:
@@ -750,6 +754,7 @@ class ProductionSystem:
                 state=cast(ProductionStateClient, None),
                 planning=cast(ProductionPlanningClient, None),
                 copies=cast(ProductionCopiesClient, None),
+                local_storage_env={},
             )
             system.collections = ProductionCollectionsClient(system)
             system.fetches = ProductionFetchesClient(system)
@@ -771,6 +776,7 @@ class ProductionSystem:
     def reset(self) -> None:
         with time_block("fixture.acceptance_system.reset"):
             self._clear_fixture_path()
+            self.local_storage_env.clear()
             self.server.reset()
 
     def request(
@@ -851,7 +857,7 @@ class ProductionSystem:
             return subprocess.run(
                 [sys.executable, "-m", "arc_cli.main", *args],
                 cwd=REPO_ROOT,
-                env=self._subprocess_env(),
+                env=self._subprocess_env(self.local_storage_env),
                 capture_output=True,
                 text=True,
                 check=False,
@@ -863,14 +869,14 @@ class ProductionSystem:
         with time_block("subprocess arc-disc"):
             if not self.fixture_path.exists():
                 self._write_arc_disc_fixture(self._default_arc_disc_fixture())
+            extra_env = {
+                "ARC_DISC_STAGING_DIR": str(self.workspace / "arc_disc_staging"),
+                **self.local_storage_env,
+            }
             return subprocess.run(
                 [sys.executable, "-m", "arc_disc.main", *args],
                 cwd=REPO_ROOT,
-                env=self._subprocess_env(
-                    {
-                        "ARC_DISC_STAGING_DIR": str(self.workspace / "arc_disc_staging"),
-                    }
-                ),
+                env=self._subprocess_env(extra_env),
                 input=input_text,
                 capture_output=True,
                 text=True,
@@ -882,6 +888,14 @@ class ProductionSystem:
 
     def set_operator_local_storage_capacity_summary_available(self) -> None:
         shutil.disk_usage(self.workspace)
+        self.local_storage_env.update(
+            {
+                "ARC_LOCAL_STORAGE_SUMMARY": "1",
+                "ARC_LOCAL_STORAGE_AVAILABLE_BYTES": str(_OPERATOR_STORAGE_AVAILABLE_BYTES),
+                "ARC_LOCAL_STORAGE_BUDGET_BYTES": str(_OPERATOR_STORAGE_BUDGET_BYTES),
+                "ARC_LOCAL_STORAGE_PATH": str(self.workspace),
+            }
+        )
 
     def set_operator_storage_capacity_blocked(self, *, statechart: str, state: str) -> None:
         assert state == "storage_capacity_blocked"
@@ -890,6 +904,15 @@ class ProductionSystem:
             "arc_disc.burn",
             "arc_disc.recovery",
         }
+        self.local_storage_env.update(
+            {
+                "ARC_LOCAL_STORAGE_AVAILABLE_BYTES": str(_OPERATOR_STORAGE_AVAILABLE_BYTES),
+                "ARC_LOCAL_STORAGE_BUDGET_BYTES": str(_OPERATOR_STORAGE_BUDGET_BYTES),
+                "ARC_LOCAL_STORAGE_REQUIRED_BYTES": str(_OPERATOR_STORAGE_REQUIRED_BYTES),
+                "ARC_LOCAL_STORAGE_WORKFLOW": "Local work",
+                "ARC_LOCAL_STORAGE_PATH": str(self.workspace),
+            }
+        )
 
     def delete_hot_backing_file(self, target: str) -> None:
         selected = self.state.selected_files(target)

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -104,6 +104,17 @@ def _feature_copy_text(name: str) -> str:
     match name:
         case "arc_home_no_attention":
             return operator_copy.arc_home_no_attention()
+        case "storage_capacity_summary":
+            return operator_copy.storage_capacity_summary(
+                available_bytes=10_737_418_240,
+                budget_bytes=21_474_836_480,
+            )
+        case "storage_capacity_blocked":
+            return operator_copy.storage_capacity_blocked(
+                workflow="Disc preparation",
+                required_bytes=8_589_934_592,
+                available_bytes=1_073_741_824,
+            )
         case "arc_item_cloud_backup_failed":
             return _guided_item_text(
                 operator_copy.arc_item_cloud_backup_failed(

--- a/tests/unit/test_operator_statecharts.py
+++ b/tests/unit/test_operator_statecharts.py
@@ -365,7 +365,7 @@ def test_mermaid_generator_writes_clear_compatible_mmdc_validated_workflows(
         _mermaid_display_text(generator.render_operator_copy("burn_label_checkpoint")) in burn
     )
     assert (
-        'restore_complete_progress_done_1{"<b>Restore Complete</b>"}:::guardNode'
+        'restore_complete_progress_done_2{"<b>Restore Complete</b>"}:::guardNode'
         in hot_recovery
     )
     assert (


### PR DESCRIPTION
## Summary
- add ADR-0045 for local storage capacity as operator-visible state
- add storage capacity summary/blockage copy and statechart coverage
- back healthy summary, upload blockage, burn blockage, and recovery materialization blockage in the spec harness
- back prod storage-capacity setup with configured local capacity/budget pressure
- implement production storage-capacity summary and blockage guidance in `arc` and `arc-disc`

## Tracking
- PM child #247 is closed
- Test child #308 is closed
- Test child #324 is closed
- Dev child #311 is closed

## Verification
- `make lint`
- `make unit args='tests/unit/test_acceptance_marker_enforcement.py'`\n- `make spec args='-k "test_arc_healthy_home_reports_local_storage_capacity_summary or test_arc_upload_reports_storagecapacity_blockage_before_lowlevel_filesystem_errors or test_arcdisc_reports_storagecapacity_blockage_during_disc_preparation or test_arcdisc_reports_storagecapacity_blockage_during_recovery_materialization"'`\n- `make prod args='-k "test_arc_healthy_home_reports_local_storage_capacity_summary or test_arc_upload_reports_storagecapacity_blockage_before_lowlevel_filesystem_errors or test_arcdisc_reports_storagecapacity_blockage_during_disc_preparation or test_arcdisc_reports_storagecapacity_blockage_during_recovery_materialization" -vv'`