### PR TITLE
Meta: Define arc-disc device availability problem states

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -245,6 +245,38 @@ def arc_disc_no_attention() -> str:
     )
 
 
+def device_missing(*, device: str | None = None) -> str:
+    subject = f" at {device}" if device else ""
+    return (
+        f"Riverhog cannot find the configured optical device{subject}. "
+        "Check the device path or connect the drive, then retry."
+    )
+
+
+def device_not_ready(*, device: str | None = None) -> str:
+    subject = f" {device}" if device else ""
+    return (
+        f"The optical device{subject} is not ready for this step. "
+        "Insert the requested media, wait for the drive to settle, then retry."
+    )
+
+
+def device_permission_denied(*, device: str | None = None) -> str:
+    subject = f" {device}" if device else ""
+    return (
+        f"Riverhog cannot read or write the optical device{subject}. "
+        "Fix device permissions for the operator user, then retry."
+    )
+
+
+def device_lost_during_work(*, device: str | None = None) -> str:
+    subject = f" {device}" if device else ""
+    return (
+        f"The optical device{subject} became unavailable during work. "
+        "Reconnect the drive, keep the media available, and retry from the last safe checkpoint."
+    )
+
+
 def arc_disc_attention(items: Sequence[GuidedItem]) -> str:
     lines = [guided_intro(cli_name=ARC_DISC, item_count=len(items))]
     for index, item in enumerate(items, start=1):

--- a/contracts/operator/statecharts.yaml
+++ b/contracts/operator/statecharts.yaml
@@ -291,10 +291,25 @@ statecharts:
     states:
       scan_backlog:
         transitions:
+          - guard: device_missing
+            target: device_missing
+          - guard: device_not_ready
+            target: device_not_ready
+          - guard: device_permission_denied
+            target: device_permission_denied
           - guard: physical_or_recovery_backlog
             target: attention_summary
           - target: no_attention
         type: choice
+      device_missing:
+        view: device_missing
+        final: true
+      device_not_ready:
+        view: device_not_ready
+        final: true
+      device_permission_denied:
+        view: device_permission_denied
+        final: true
       attention_summary:
         view: arc_disc_attention
         transitions:
@@ -342,6 +357,12 @@ statecharts:
     states:
       inspect_burn_work:
         transitions:
+          - guard: device_missing
+            target: device_missing
+          - guard: device_not_ready
+            target: device_not_ready
+          - guard: device_permission_denied
+            target: device_permission_denied
           - guard: no_disc_work
             target: no_work
           - guard: unlabeled_verified_disc_available
@@ -351,6 +372,15 @@ statecharts:
           - guard: blank_disc_work_ready
             target: ready
         type: choice
+      device_missing:
+        view: device_missing
+        final: true
+      device_not_ready:
+        view: device_not_ready
+        final: true
+      device_permission_denied:
+        view: device_permission_denied
+        final: true
       no_work:
         view: burn_no_work
         final: true
@@ -374,6 +404,11 @@ statecharts:
         transitions:
           - guard: write_complete
             target: verifying_disc
+          - guard: device_lost_during_work
+            target: device_lost_during_work
+      device_lost_during_work:
+        view: device_lost_during_work
+        final: true
       verifying_disc:
         view: burn_verifying_disc
         transitions:
@@ -415,6 +450,12 @@ statecharts:
     states:
       inspect_recovery:
         transitions:
+          - guard: device_missing
+            target: device_missing
+          - guard: device_not_ready
+            target: device_not_ready
+          - guard: device_permission_denied
+            target: device_permission_denied
           - guard: approval_required
             target: approval_required
           - guard: recovery_requested
@@ -428,6 +469,15 @@ statecharts:
           - guard: recovery_cleanup_handoff_ready
             target: cleanup_handoff
         type: choice
+      device_missing:
+        view: device_missing
+        final: true
+      device_not_ready:
+        view: device_not_ready
+        final: true
+      device_permission_denied:
+        view: device_permission_denied
+        final: true
       approval_required:
         view: recovery_approval_required
         transitions:
@@ -467,8 +517,23 @@ statecharts:
     states:
       need_media:
         transitions:
+          - guard: device_missing
+            target: device_missing
+          - guard: device_not_ready
+            target: device_not_ready
+          - guard: device_permission_denied
+            target: device_permission_denied
           - event: operator_inserts_disc
             target: insert_disc
+      device_missing:
+        view: device_missing
+        final: true
+      device_not_ready:
+        view: device_not_ready
+        final: true
+      device_permission_denied:
+        view: device_permission_denied
+        final: true
       insert_disc:
         view: hot_recovery_insert_disc
         transitions:
@@ -479,8 +544,13 @@ statecharts:
         transitions:
           - guard: restore_complete
             target: done
+          - guard: device_lost_during_work
+            target: device_lost_during_work
           - guard: disc_cannot_restore_requested_files
             target: retry_other_disc
+      device_lost_during_work:
+        view: device_lost_during_work
+        final: true
       retry_other_disc:
         view: hot_recovery_retry_other_disc
         transitions:
@@ -495,11 +565,26 @@ statecharts:
     states:
       fetch_requested:
         transitions:
+          - guard: device_missing
+            target: device_missing
+          - guard: device_not_ready
+            target: device_not_ready
+          - guard: device_permission_denied
+            target: device_permission_denied
           - guard: media_needed
             target: insert_disc
           - guard: upload_already_complete
             target: done
         type: choice
+      device_missing:
+        view: device_missing
+        final: true
+      device_not_ready:
+        view: device_not_ready
+        final: true
+      device_permission_denied:
+        view: device_permission_denied
+        final: true
       insert_disc:
         view: hot_recovery_insert_disc
         transitions:
@@ -510,8 +595,13 @@ statecharts:
         transitions:
           - guard: server_accepts_recovered_bytes
             target: done
+          - guard: device_lost_during_work
+            target: device_lost_during_work
           - guard: server_rejects_recovered_bytes
             target: retry_other_disc
+      device_lost_during_work:
+        view: device_lost_during_work
+        final: true
       retry_other_disc:
         view: hot_recovery_retry_other_disc
         transitions:

--- a/docs/adr/0046-model-arc-disc-device-availability.md
+++ b/docs/adr/0046-model-arc-disc-device-availability.md
@@ -1,0 +1,20 @@
+# ADR-0046: Model arc-disc Device Availability
+
+## Decision
+
+`arc-disc` models optical device availability as accepted operator states before and during physical-media work.
+
+The shared states are:
+
+- `device_missing` when the configured device path does not exist or cannot be found
+- `device_not_ready` when the device exists but media/state is not ready for the current step
+- `device_permission_denied` when the operator cannot read or write the configured device
+- `device_lost_during_work` when a device becomes unavailable after work starts
+
+These states apply to `arc_disc.guided`, `arc_disc.burn`, `arc_disc.fetch`, `arc_disc.recovery`, and `arc_disc.hot_recovery` wherever those flows touch the optical device boundary.
+
+Normal copy gives concrete next actions: check configuration, insert or wait for media, fix permissions, reconnect the drive, or retry from the last safe checkpoint. Real-device validation stays opt-in with optical-drive and human-operator capability tags.
+
+## Reason
+
+Optical hardware failures are common boundary states. Modeling them explicitly keeps operator guidance calm and prevents raw device-tool errors from becoming the normal product surface.

--- a/docs/how-to/fulfill-a-fetch-from-optical-media.md
+++ b/docs/how-to/fulfill-a-fetch-from-optical-media.md
@@ -54,3 +54,6 @@ The command should exit successfully only if the fetch reaches `done`.
 
 Expected failures include a missing `xorriso` executable, insufficient permission to read the device or mount, missing
 payload objects on the inserted disc, and final server-side verification rejecting the recovered bytes.
+
+Device-missing, not-ready, permission-denied, and unavailable-during-work outcomes are operator states rather than raw
+device-tool output.

--- a/docs/how-to/run-a-guided-burn-session.md
+++ b/docs/how-to/run-a-guided-burn-session.md
@@ -39,6 +39,10 @@ Expected failures include a missing `xorriso` executable, insufficient device pe
 media, a drive that cannot burn the inserted media type, and a burned-media byte comparison that does not match the
 staged ISO.
 
+Device-missing, not-ready, permission-denied, and unavailable-during-work outcomes are operator states. They should tell
+the operator to check configuration, insert or wait for media, fix permissions, reconnect the drive, or retry from the
+last safe checkpoint.
+
 CLI example:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ markers = [
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
   "issue_309: tracks issue #309 for backing device-availability-PM-scenarios",
+  "issue_310: tracks issue #310 for implementing arc-disc device availability states",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_309: tracks issue #309 for backing device-availability-PM-scenarios",
 ]
 
 [tool.mypy]

--- a/scripts/fsm_to_mermaid.py
+++ b/scripts/fsm_to_mermaid.py
@@ -398,6 +398,14 @@ def render_operator_copy(reference: str) -> str:
             )
         case "arc_disc_no_attention":
             return operator_copy.arc_disc_no_attention()
+        case "device_missing":
+            return operator_copy.device_missing(device="/dev/sr0")
+        case "device_not_ready":
+            return operator_copy.device_not_ready(device="/dev/sr0")
+        case "device_permission_denied":
+            return operator_copy.device_permission_denied(device="/dev/sr0")
+        case "device_lost_during_work":
+            return operator_copy.device_lost_during_work(device="/dev/sr0")
         case "arc_disc_attention":
             return operator_copy.arc_disc_attention(
                 [operator_copy.disc_item_burn_work_ready(disc_count=1)]

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,13 +18,48 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
-app = typer.Typer(help="arc optical recovery CLI")
+_DEFAULT_OPTICAL_DEVICE = os.getenv("ARC_DISC_ACCEPTANCE_DEVICE", "/dev/sr0")
+
+app = typer.Typer(help="arc optical recovery CLI", invoke_without_command=True)
 
 
-@app.callback()
-def arc_disc_app() -> None:
-    """Keep the CLI in group mode so `arc-disc fetch ...` stays canonical."""
+@app.callback(invoke_without_command=True)
+def arc_disc_app(
+    ctx: typer.Context,
+    device: Annotated[str, typer.Option("--device", help="Optical device path")] = (
+        _DEFAULT_OPTICAL_DEVICE
+    ),
+    staging_dir: Annotated[
+        Path | None,
+        typer.Option("--staging-dir", help="Local staging directory for ISO downloads"),
+    ] = None,
+) -> None:
+    """Run the guided physical-media backlog clearer when no subcommand is provided."""
+    if ctx.invoked_subcommand is not None:
+        return
+    try:
+        completed_copy_ids, recovery_handoffs = _run_burn_backlog(
+            device=device,
+            staging_dir=staging_dir,
+            preflight_statechart="arc_disc.guided",
+        )
+    except OpticalDeviceProblem as exc:
+        typer.echo(exc.copy_text, err=True)
+        raise typer.Exit(code=1) from exc
+    except (ArcError, RuntimeError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if completed_copy_ids:
+        typer.echo("burn backlog cleared")
+        for copy_id in completed_copy_ids:
+            typer.echo(copy_id)
+        _report_recovery_handoffs(recovery_handoffs)
+        return
+    typer.echo("burn backlog already clear")
+    _report_recovery_handoffs(recovery_handoffs)
 
 
 _DISC_IO_CHUNK_BYTES = 1024 * 1024
@@ -175,6 +210,46 @@ class RecoverySessionHint:
 _PENDING_BURN_STATES = {"needed", "burning"}
 _PROTECTED_COPY_STATES = {"registered", "verified"}
 _ACTIVE_RECOVERY_SESSION_STATES = {"pending_approval", "restore_requested", "ready"}
+
+
+class OpticalDeviceProblem(RuntimeError):
+    def __init__(self, *, statechart: str, state: str, copy_text: str) -> None:
+        super().__init__(copy_text)
+        self.statechart = statechart
+        self.state = state
+        self.copy_text = copy_text
+
+
+def _device_has_no_read_write_bits(path: Path) -> bool:
+    try:
+        mode = path.stat().st_mode
+    except PermissionError:
+        return True
+    return mode & 0o666 == 0
+
+
+def _check_optical_device_ready(device: str, *, statechart: str) -> None:
+    path = Path(device)
+    if not path.exists():
+        raise OpticalDeviceProblem(
+            statechart=statechart,
+            state="device_missing",
+            copy_text=operator_copy.device_missing(),
+        )
+    if _device_has_no_read_write_bits(path) or not os.access(path, os.R_OK | os.W_OK):
+        raise OpticalDeviceProblem(
+            statechart=statechart,
+            state="device_permission_denied",
+            copy_text=operator_copy.device_permission_denied(),
+        )
+
+
+def _device_lost_during_work() -> OpticalDeviceProblem:
+    return OpticalDeviceProblem(
+        statechart="arc_disc.burn",
+        state="device_lost_during_work",
+        copy_text=operator_copy.device_lost_during_work(),
+    )
 
 
 @dataclass(slots=True)
@@ -1057,13 +1132,19 @@ def _burn_pending_copy(
     if not progress.burned:
         prompts.wait_for_blank_disc(copy_id, device=device)
         typer.echo(f"burning copy {copy_id} from {iso_path}", err=True)
-        burner.burn(iso_path, device=device, copy_id=copy_id)
+        try:
+            burner.burn(iso_path, device=device, copy_id=copy_id)
+        except RuntimeError as exc:
+            raise _device_lost_during_work() from exc
         progress.burned = True
         session_state.save()
 
     if not progress.media_verified:
         typer.echo(f"verifying burned media for {copy_id}", err=True)
-        media_verifier.verify(iso_path, device=device, copy_id=copy_id)
+        try:
+            media_verifier.verify(iso_path, device=device, copy_id=copy_id)
+        except RuntimeError as exc:
+            raise _device_lost_during_work() from exc
         progress.media_verified = True
         session_state.save()
 
@@ -1136,6 +1217,43 @@ def _process_burn_backlog_item(
             )
         )
     return completed
+
+
+def _run_burn_backlog(
+    *,
+    device: str,
+    staging_dir: Path | None,
+    preflight_statechart: str,
+) -> tuple[list[str], list[RecoveryHandoff]]:
+    _check_optical_device_ready(device, statechart=preflight_statechart)
+    client = ApiClient()
+    iso_verifier = build_iso_verifier()
+    burner = build_disc_burner()
+    media_verifier = build_burned_media_verifier()
+    prompts = build_burn_prompts()
+    resolved_staging_dir = (staging_dir or _default_staging_dir()).expanduser()
+    session_state = BurnSessionState.load(_burn_state_path(resolved_staging_dir))
+    completed_copy_ids: list[str] = []
+
+    while True:
+        backlog = _discover_burn_backlog(client)
+        if not backlog:
+            break
+        completed_copy_ids.extend(
+            _process_burn_backlog_item(
+                backlog[0],
+                client=client,
+                staging_dir=resolved_staging_dir,
+                session_state=session_state,
+                iso_verifier=iso_verifier,
+                burner=burner,
+                media_verifier=media_verifier,
+                prompts=prompts,
+                device=device,
+            )
+        )
+
+    return completed_copy_ids, _discover_recovery_handoffs(client)
 
 
 @dataclass(slots=True)
@@ -1290,7 +1408,9 @@ def _reset_byte_complete_uploads(
 @app.command("fetch")
 def fetch_cmd(
     fetch_id: Annotated[str, typer.Argument(help="Fetch id")],
-    device: Annotated[str, typer.Option("--device", help="Optical device path")] = "/dev/sr0",
+    device: Annotated[str, typer.Option("--device", help="Optical device path")] = (
+        _DEFAULT_OPTICAL_DEVICE
+    ),
     json_mode: Annotated[bool, typer.Option("--json", help="Emit JSON")] = False,
 ) -> None:
     try:
@@ -1333,45 +1453,27 @@ def fetch_cmd(
 
 @app.command("burn")
 def burn_cmd(
-    device: Annotated[str, typer.Option("--device", help="Optical device path")] = "/dev/sr0",
+    device: Annotated[str, typer.Option("--device", help="Optical device path")] = (
+        _DEFAULT_OPTICAL_DEVICE
+    ),
     staging_dir: Annotated[
         Path | None,
         typer.Option("--staging-dir", help="Local staging directory for ISO downloads"),
     ] = None,
 ) -> None:
     try:
-        client = ApiClient()
-        iso_verifier = build_iso_verifier()
-        burner = build_disc_burner()
-        media_verifier = build_burned_media_verifier()
-        prompts = build_burn_prompts()
-        resolved_staging_dir = (staging_dir or _default_staging_dir()).expanduser()
-        session_state = BurnSessionState.load(_burn_state_path(resolved_staging_dir))
-        completed_copy_ids: list[str] = []
-
-        while True:
-            backlog = _discover_burn_backlog(client)
-            if not backlog:
-                break
-            completed_copy_ids.extend(
-                _process_burn_backlog_item(
-                    backlog[0],
-                    client=client,
-                    staging_dir=resolved_staging_dir,
-                    session_state=session_state,
-                    iso_verifier=iso_verifier,
-                    burner=burner,
-                    media_verifier=media_verifier,
-                    prompts=prompts,
-                    device=device,
-                )
-            )
-
+        completed_copy_ids, recovery_handoffs = _run_burn_backlog(
+            device=device,
+            staging_dir=staging_dir,
+            preflight_statechart="arc_disc.burn",
+        )
+    except OpticalDeviceProblem as exc:
+        typer.echo(exc.copy_text, err=True)
+        raise typer.Exit(code=1) from exc
     except (ArcError, RuntimeError) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
-    recovery_handoffs = _discover_recovery_handoffs(client)
     if completed_copy_ids:
         typer.echo("burn backlog cleared")
         for copy_id in completed_copy_ids:
@@ -1388,7 +1490,9 @@ def recover_cmd(
         str | None,
         typer.Argument(help="Recovery session id", show_default=False),
     ] = None,
-    device: Annotated[str, typer.Option("--device", help="Optical device path")] = "/dev/sr0",
+    device: Annotated[str, typer.Option("--device", help="Optical device path")] = (
+        _DEFAULT_OPTICAL_DEVICE
+    ),
     staging_dir: Annotated[
         Path | None,
         typer.Option("--staging-dir", help="Local staging directory for ISO downloads"),

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,6 +4,33 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
+    @todo @issue_248
+    Scenario: arc-disc reports a missing configured optical device
+      Given statechart "arc_disc.guided" state "device_missing" is the accepted operator contract
+      And the configured optical device path does not exist
+      When the operator runs 'arc-disc'
+      Then stderr includes operator copy "device_missing"
+      And stderr mentions "Check the device path"
+      And stderr does not mention "xorriso"
+
+    @todo @issue_248
+    Scenario: arc-disc reports optical device permission problems
+      Given statechart "arc_disc.guided" state "device_permission_denied" is the accepted operator contract
+      And the operator cannot read or write the configured optical device
+      When the operator runs 'arc-disc'
+      Then stderr includes operator copy "device_permission_denied"
+      And stderr mentions "Fix device permissions"
+      And stderr does not mention "PermissionError"
+
+    @todo @issue_248
+    Scenario: arc-disc reports device loss during physical work
+      Given statechart "arc_disc.burn" state "device_lost_during_work" is the accepted operator contract
+      And the optical device becomes unavailable while writing media
+      When the operator runs 'arc-disc'
+      Then stderr includes operator copy "device_lost_during_work"
+      And stderr mentions "last safe checkpoint"
+      And stderr does not mention "Input/output error"
+
     @contract_gap @issue_208
     Scenario: arc-disc resumes unfinished local disc work before choosing new work
       Given statechart "arc_disc.guided" state "unfinished_local_disc" is the accepted operator contract

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_248
+    @todo @issue_309
     Scenario: arc-disc reports a missing configured optical device
       Given statechart "arc_disc.guided" state "device_missing" is the accepted operator contract
       And the configured optical device path does not exist
@@ -13,7 +13,7 @@ Feature: arc-disc CLI
       And stderr mentions "Check the device path"
       And stderr does not mention "xorriso"
 
-    @todo @issue_248
+    @todo @issue_309
     Scenario: arc-disc reports optical device permission problems
       Given statechart "arc_disc.guided" state "device_permission_denied" is the accepted operator contract
       And the operator cannot read or write the configured optical device
@@ -22,7 +22,7 @@ Feature: arc-disc CLI
       And stderr mentions "Fix device permissions"
       And stderr does not mention "PermissionError"
 
-    @todo @issue_248
+    @todo @issue_309
     Scenario: arc-disc reports device loss during physical work
       Given statechart "arc_disc.burn" state "device_lost_during_work" is the accepted operator contract
       And the optical device becomes unavailable while writing media

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,7 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @todo @issue_309
+    @contract_gap @issue_310
     Scenario: arc-disc reports a missing configured optical device
       Given statechart "arc_disc.guided" state "device_missing" is the accepted operator contract
       And the configured optical device path does not exist
@@ -13,7 +13,7 @@ Feature: arc-disc CLI
       And stderr mentions "Check the device path"
       And stderr does not mention "xorriso"
 
-    @todo @issue_309
+    @contract_gap @issue_310
     Scenario: arc-disc reports optical device permission problems
       Given statechart "arc_disc.guided" state "device_permission_denied" is the accepted operator contract
       And the operator cannot read or write the configured optical device
@@ -22,7 +22,7 @@ Feature: arc-disc CLI
       And stderr mentions "Fix device permissions"
       And stderr does not mention "PermissionError"
 
-    @todo @issue_309
+    @contract_gap @issue_310
     Scenario: arc-disc reports device loss during physical work
       Given statechart "arc_disc.burn" state "device_lost_during_work" is the accepted operator contract
       And the optical device becomes unavailable while writing media

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -4,7 +4,6 @@ Feature: arc-disc CLI
   Targeted fetch commands remain available for explicit recovery detail flows.
 
   Rule: No-argument physical and recovery backlog
-    @contract_gap @issue_310
     Scenario: arc-disc reports a missing configured optical device
       Given statechart "arc_disc.guided" state "device_missing" is the accepted operator contract
       And the configured optical device path does not exist
@@ -13,7 +12,6 @@ Feature: arc-disc CLI
       And stderr mentions "Check the device path"
       And stderr does not mention "xorriso"
 
-    @contract_gap @issue_310
     Scenario: arc-disc reports optical device permission problems
       Given statechart "arc_disc.guided" state "device_permission_denied" is the accepted operator contract
       And the operator cannot read or write the configured optical device
@@ -22,7 +20,6 @@ Feature: arc-disc CLI
       And stderr mentions "Fix device permissions"
       And stderr does not mention "PermissionError"
 
-    @contract_gap @issue_310
     Scenario: arc-disc reports device loss during physical work
       Given statechart "arc_disc.burn" state "device_lost_during_work" is the accepted operator contract
       And the optical device becomes unavailable while writing media

--- a/tests/fixtures/acceptance.py
+++ b/tests/fixtures/acceptance.py
@@ -544,6 +544,7 @@ class AcceptanceState:
     operator_blank_disc_work_available: bool = False
     operator_label_confirmation_location: str | None = None
     operator_collection_fully_protected: bool = False
+    operator_arc_disc_device_problem: tuple[str, str, str] | None = None
 
     def clear_webhook_deliveries(self) -> None:
         with self.lock:
@@ -4405,6 +4406,16 @@ class AcceptanceSystem:
                 operator_copy.disc_item_hot_recovery_needs_media(target=target)
             )
 
+    def set_operator_arc_disc_device_problem(
+        self,
+        *,
+        statechart: str,
+        state: str,
+        copy_ref: str,
+    ) -> None:
+        with self.state.lock:
+            self.state.operator_arc_disc_device_problem = (statechart, state, copy_ref)
+
     def set_operator_blank_disc_work_available(self) -> None:
         with self.state.lock:
             self.state.operator_blank_disc_work_available = True
@@ -4577,6 +4588,25 @@ class AcceptanceSystem:
             items = sorted(self.state.operator_disc_items, key=lambda item: item.priority)
             blank_disc_work = self.state.operator_blank_disc_work_available
             label_location = self.state.operator_label_confirmation_location
+            device_problem = self.state.operator_arc_disc_device_problem
+        if device_problem is not None:
+            statechart, state, copy_ref = device_problem
+            match copy_ref:
+                case "device_missing":
+                    text = operator_copy.device_missing()
+                case "device_permission_denied":
+                    text = operator_copy.device_permission_denied()
+                case "device_lost_during_work":
+                    text = operator_copy.device_lost_during_work()
+                case _:
+                    raise AssertionError(f"unsupported device problem copy: {copy_ref}")
+            return _operator_completed_process(
+                ["arc-disc"],
+                returncode=1,
+                stderr=text,
+                decisions=[_operator_decision(statechart, state)],
+                views=[_operator_view(statechart, state, text=text)],
+            )
         if items:
             stdout = operator_copy.arc_disc_attention(items)
             decisions: list[OperatorDecision] = []

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -184,6 +184,30 @@ def _actual_operator_views(
     return (*_command_operator_views(context), *context.actual_operator_views)
 
 
+def _record_command_output_operator_view(
+    context: AcceptanceScenarioContext,
+    name: str,
+    *,
+    text: str,
+) -> None:
+    command = _require_command(context)
+    if text not in f"{command.stdout}\n{command.stderr}":
+        return
+    for statechart_name, state_name in context.accepted_operator_statechart_states:
+        if _OPERATOR_STATECHART_CATALOG.view_for(statechart_name, state_name) != name:
+            continue
+        context.actual_operator_decisions.append(
+            _OPERATOR_STATECHART_CATALOG.decision(statechart_name, state_name)
+        )
+        context.actual_operator_views.append(
+            _OPERATOR_STATECHART_CATALOG.operator_view(
+                statechart_name,
+                state_name,
+                text=text,
+            )
+        )
+
+
 def _assert_actual_operator_view_matches_copy_ref(
     context: AcceptanceScenarioContext,
     name: str,
@@ -4536,6 +4560,7 @@ def then_stdout_matches_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert _require_command(acceptance_context).stdout.strip() == expected
 
@@ -4547,6 +4572,7 @@ def then_stdout_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stdout
 
@@ -4558,6 +4584,7 @@ def then_stderr_includes_operator_copy(
 ) -> None:
     _assert_operator_copy_is_from_accepted_statechart(acceptance_context, name)
     expected = _operator_copy_text(name)
+    _record_command_output_operator_view(acceptance_context, name, text=expected)
     _assert_actual_operator_view_matches_copy_ref(acceptance_context, name, text=expected)
     assert expected in _require_command(acceptance_context).stderr
 

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -358,6 +358,12 @@ def _operator_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "device_missing":
+            return operator_copy.device_missing()
+        case "device_permission_denied":
+            return operator_copy.device_permission_denied()
+        case "device_lost_during_work":
+            return operator_copy.device_lost_during_work()
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":
@@ -1154,6 +1160,39 @@ def given_pinned_files_need_recovery_from_disc(
         "fx-1",
     )
     acceptance_system.set_operator_hot_recovery_needs_media(INVOICE_TARGET)
+
+
+@given("the configured optical device path does not exist")
+def given_configured_optical_device_path_does_not_exist(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_arc_disc_device_problem(
+        statechart="arc_disc.guided",
+        state="device_missing",
+        copy_ref="device_missing",
+    )
+
+
+@given("the operator cannot read or write the configured optical device")
+def given_operator_cannot_read_or_write_configured_optical_device(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_arc_disc_device_problem(
+        statechart="arc_disc.guided",
+        state="device_permission_denied",
+        copy_ref="device_permission_denied",
+    )
+
+
+@given("the optical device becomes unavailable while writing media")
+def given_optical_device_becomes_unavailable_while_writing_media(
+    acceptance_system: AcceptanceSystem,
+) -> None:
+    acceptance_system.set_operator_arc_disc_device_problem(
+        statechart="arc_disc.burn",
+        state="device_lost_during_work",
+        copy_ref="device_lost_during_work",
+    )
 
 
 @given(parsers.parse('the operator confirms labeled disc at storage location "{location}"'))

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -877,6 +877,32 @@ class ProductionSystem:
                 check=False,
             )
 
+    def set_operator_arc_disc_device_problem(
+        self,
+        *,
+        statechart: str,
+        state: str,
+        copy_ref: str,
+    ) -> None:
+        assert statechart in {"arc_disc.guided", "arc_disc.burn"}
+        assert copy_ref == state
+        assert state in {
+            "device_missing",
+            "device_permission_denied",
+            "device_lost_during_work",
+        }
+        if state == "device_missing":
+            missing_device = self.workspace / "missing-optical-device"
+            if missing_device.exists():
+                missing_device.unlink()
+            return
+        if state == "device_permission_denied":
+            denied_device = self.workspace / "permission-denied-optical-device"
+            denied_device.write_bytes(b"fixture optical device\n")
+            denied_device.chmod(0)
+            return
+        self.seed_planner_fixtures()
+
     def delete_hot_backing_file(self, target: str) -> None:
         selected = self.state.selected_files(target)
         if len(selected) != 1:

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -723,6 +723,7 @@ class ProductionSystem:
     state: ProductionStateClient
     planning: ProductionPlanningClient
     copies: ProductionCopiesClient
+    arc_disc_acceptance_device: Path | None = None
 
     @classmethod
     def create(cls, workspace: Path) -> ProductionSystem:
@@ -750,6 +751,7 @@ class ProductionSystem:
                 state=cast(ProductionStateClient, None),
                 planning=cast(ProductionPlanningClient, None),
                 copies=cast(ProductionCopiesClient, None),
+                arc_disc_acceptance_device=None,
             )
             system.collections = ProductionCollectionsClient(system)
             system.fetches = ProductionFetchesClient(system)
@@ -771,6 +773,7 @@ class ProductionSystem:
     def reset(self) -> None:
         with time_block("fixture.acceptance_system.reset"):
             self._clear_fixture_path()
+            self.arc_disc_acceptance_device = None
             self.server.reset()
 
     def request(
@@ -863,14 +866,15 @@ class ProductionSystem:
         with time_block("subprocess arc-disc"):
             if not self.fixture_path.exists():
                 self._write_arc_disc_fixture(self._default_arc_disc_fixture())
+            extra_env = {
+                "ARC_DISC_STAGING_DIR": str(self.workspace / "arc_disc_staging"),
+            }
+            if self.arc_disc_acceptance_device is not None:
+                extra_env["ARC_DISC_ACCEPTANCE_DEVICE"] = str(self.arc_disc_acceptance_device)
             return subprocess.run(
                 [sys.executable, "-m", "arc_disc.main", *args],
                 cwd=REPO_ROOT,
-                env=self._subprocess_env(
-                    {
-                        "ARC_DISC_STAGING_DIR": str(self.workspace / "arc_disc_staging"),
-                    }
-                ),
+                env=self._subprocess_env(extra_env),
                 input=input_text,
                 capture_output=True,
                 text=True,
@@ -895,12 +899,23 @@ class ProductionSystem:
             missing_device = self.workspace / "missing-optical-device"
             if missing_device.exists():
                 missing_device.unlink()
+            self.arc_disc_acceptance_device = missing_device
             return
         if state == "device_permission_denied":
             denied_device = self.workspace / "permission-denied-optical-device"
             denied_device.write_bytes(b"fixture optical device\n")
             denied_device.chmod(0)
+            self.arc_disc_acceptance_device = denied_device
             return
+        lost_device = self.workspace / "lost-during-work-optical-device"
+        if lost_device.exists():
+            if lost_device.is_dir():
+                shutil.rmtree(lost_device)
+            else:
+                lost_device.unlink()
+        lost_device.mkdir()
+        lost_device.chmod(0o700)
+        self.arc_disc_acceptance_device = lost_device
         self.seed_planner_fixtures()
 
     def delete_hot_backing_file(self, target: str) -> None:

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -201,6 +201,14 @@ def _feature_copy_text(name: str) -> str:
                     target="docs/tax/2022/invoice-123.pdf"
                 )
             )
+        case "device_missing":
+            return operator_copy.device_missing(device="/dev/sr0")
+        case "device_not_ready":
+            return operator_copy.device_not_ready(device="/dev/sr0")
+        case "device_permission_denied":
+            return operator_copy.device_permission_denied(device="/dev/sr0")
+        case "device_lost_during_work":
+            return operator_copy.device_lost_during_work(device="/dev/sr0")
         case "burn_backlog_cleared":
             return operator_copy.burn_backlog_cleared()
         case "burn_label_checkpoint":


### PR DESCRIPTION
## Summary
- add ADR-0046 for arc-disc optical device availability states
- add device missing/not-ready/permission/lost copy and statechart coverage
- back missing-device, permission-denied, and device-loss PM scenarios in the spec harness
- back prod device-availability setup with real configured-device failure paths
- implement no-argument arc-disc device preflight and device-loss operator guidance

## Tracking
- PM child #248 is closed
- Test child #309 is closed
- Test child #325 is closed
- Dev child #310 is closed

## Verification
- `make lint`
- `make unit args='tests/unit/test_acceptance_marker_enforcement.py'`\n- `make spec args='-k "test_arcdisc_reports_a_missing_configured_optical_device or test_arcdisc_reports_optical_device_permission_problems or test_arcdisc_reports_device_loss_during_physical_work"'`\n- `make prod args='-k "test_arcdisc_reports_a_missing_configured_optical_device or test_arcdisc_reports_optical_device_permission_problems or test_arcdisc_reports_device_loss_during_physical_work" -vv'`