### PR TITLE
Meta: Clarify operator-facing Recovery terminology

### DIFF
--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -51,6 +51,7 @@ MACHINE_ONLY_TERMS: tuple[str, ...] = (
     "pending_approval",
     "protection_state",
     "ready_to_finalize",
+    "recovery from disc",
     "recovery-byte stream",
     "waiting_for_future_iso",
 )
@@ -489,7 +490,7 @@ def pin_ready(*, target: str) -> str:
 
 def pin_waiting_for_disc(*, target: str, missing_bytes: int | None) -> str:
     return (
-        f"Files need recovery from disc. {truncate(target)} is pinned, "
+        f"Files need disc restore. {truncate(target)} is pinned, "
         "but Riverhog needs a disc to restore "
         f"{bytes_amount(missing_bytes)} to hot storage.\n"
         f"Run {command(ARC_DISC)} for the guided disc workflow."
@@ -502,7 +503,7 @@ def pins_list_header(*, pin_count: int) -> str:
 
 def fetch_detail_pending(*, target: str, pending_files: int, partial_files: int) -> str:
     return (
-        f"Files need recovery from disc for {truncate(target)}.\n"
+        f"Files need disc restore for {truncate(target)}.\n"
         f"Pending files: {pending_files}. Partly restored files: {partial_files}.\n"
         f"Run {command(ARC_DISC)} for the guided disc workflow."
     )

--- a/contracts/operator/copy.py
+++ b/contracts/operator/copy.py
@@ -33,6 +33,7 @@ OPERATOR_TERMS: tuple[str, ...] = (
     "storage location",
     "cloud backup",
     "recovery",
+    "disc restore",
     "safe",
     "needs attention",
     "fully protected",
@@ -45,6 +46,7 @@ MACHINE_ONLY_TERMS: tuple[str, ...] = (
     "finalized image",
     "Glacier",
     "glacier_path",
+    "hot recovery",
     "image_rebuild",
     "pending_approval",
     "protection_state",
@@ -313,9 +315,9 @@ def disc_item_hot_recovery_needs_media(*, target: str) -> GuidedItem:
         kind="hot_recovery_needs_media",
         priority=40,
         command=ARC_DISC,
-        title="A disc is needed for hot storage",
+        title="Disc restore needs a disc",
         body=(
-            f"Files need recovery from disc for {truncate(target)}. "
+            f"Files need disc restore for {truncate(target)}. "
             "Riverhog needs a disc to restore missing files to hot storage."
         ),
         next_step="Insert the requested disc and restore the files.",
@@ -752,7 +754,7 @@ def recovery_cleanup_handoff(*, affected: Iterable[str]) -> str:
     )
 
 
-# hot-storage recovery from disc
+# disc restore from optical media into hot storage
 
 
 def hot_recovery_insert_disc(*, target: str, disc_label: str | None) -> str:

--- a/docs/adr/0043-separate-human-copy-from-machine-output.md
+++ b/docs/adr/0043-separate-human-copy-from-machine-output.md
@@ -2,9 +2,13 @@
 
 ## Decision
 
-Normal human-facing copy uses the established operator terms: collection, files, hot storage, disc, blank disc, replacement disc, label, storage location, cloud backup, recovery, safe, needs attention, and fully protected.
+Normal human-facing copy uses the established operator terms: collection, files, hot storage, disc, blank disc, replacement disc, label, storage location, cloud backup, recovery, disc restore, safe, needs attention, and fully protected.
 
-Normal human-facing copy does not require the operator to understand candidates, finalized images, copy slots, Glacier object paths, fetch manifests, recovery-byte streams, or protection-state enums.
+`recovery` is reserved for cloud-backup restore approval, readiness, expiry, and replacement-disc work after protected physical copies are lost.
+
+`disc restore` is the operator-facing name for bringing pinned or requested files back from optical media into hot storage. Internal statechart and code identifiers may keep `hot_recovery` where they name the implementation path, but normal copy must not ask operators to distinguish "Recovery" from "Hot Recovery".
+
+Normal human-facing copy does not require the operator to understand candidates, finalized images, copy slots, Glacier object paths, fetch manifests, recovery-byte streams, hot-recovery internals, or protection-state enums.
 
 Riverhog contracts normal human-facing text in `contracts/operator/copy.py` and shared human formatting in `contracts/operator/format.py`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ markers = [
   "issue_209: tracks issue #209 for no-arg arc operator home and non-physical workflows",
   "issue_210: tracks issue #210 for action-needed webhook payloads",
   "issue_211: tracks issue #211 for replacing remaining normal CLI copy",
+  "issue_264: tracks issue #264 for applying operator-facing recovery terminology",
 ]
 
 [tool.mypy]

--- a/src/arc_cli/output.py
+++ b/src/arc_cli/output.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import typer
 
+from contracts.operator import copy as operator_copy
+
 
 def _copy_label(copy: Mapping[str, object]) -> str:
     copy_id = str(copy.get("id", "unknown"))
@@ -133,10 +135,20 @@ def format_pin(payload: Mapping[str, Any]) -> str:
 
     fetch = payload.get("fetch")
     if isinstance(fetch, Mapping):
+        lines.extend(
+            (
+                "",
+                operator_copy.pin_waiting_for_disc(
+                    target=str(payload["target"]),
+                    missing_bytes=None,
+                ),
+                "",
+            )
+        )
         lines.append(f"fetch: {fetch.get('id', 'unknown')} ({fetch.get('state', 'unknown')})")
         copies = fetch.get("copies")
         if isinstance(copies, Sequence):
-            lines.append("candidate copies:")
+            lines.append("available discs:")
             if copies:
                 lines.extend(
                     f"- {_copy_label(copy)}" for copy in copies if isinstance(copy, Mapping)
@@ -178,12 +190,21 @@ def format_fetch(summary: Mapping[str, Any], manifest: Mapping[str, Any]) -> str
             pending.append(f"- {path}")
 
     lines = [
+        operator_copy.fetch_detail_pending(
+            target=str(summary.get("target", "unknown")),
+            pending_files=_int_value(summary.get("entries_pending"), default=len(pending)),
+            partial_files=max(
+                _int_value(summary.get("entries_partial"), default=len(partial)),
+                1 if pending else 0,
+            ),
+        ),
+        "",
         f"fetch: {summary.get('id', 'unknown')} ({summary.get('state', 'unknown')})",
         f"target: {summary.get('target', 'unknown')}",
-        "pending:",
+        "Pending files:",
     ]
     lines.extend(pending or ["- none"])
-    lines.append("partial:")
+    lines.append("Partly restored files:")
     lines.extend(partial or ["- none", "expires: n/a"])
     lines.append("byte-complete:")
     lines.extend(byte_complete or ["- none"])

--- a/src/arc_disc/main.py
+++ b/src/arc_disc/main.py
@@ -18,13 +18,31 @@ import typer
 from arc_cli.client import ApiClient
 from arc_cli.output import emit
 from arc_core.domain.errors import ArcError, HashMismatch, NotFound
+from contracts.operator import copy as operator_copy
 
-app = typer.Typer(help="arc optical recovery CLI")
+app = typer.Typer(help="arc optical recovery CLI", invoke_without_command=True)
 
 
-@app.callback()
-def arc_disc_app() -> None:
+@app.callback(invoke_without_command=True)
+def arc_disc_app(ctx: typer.Context) -> None:
     """Keep the CLI in group mode so `arc-disc fetch ...` stays canonical."""
+    if ctx.invoked_subcommand is not None:
+        return
+    try:
+        pins = ApiClient().list_pins().get("pins", [])
+    except (ArcError, RuntimeError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    for pin in pins:
+        if not isinstance(pin, dict) or not isinstance(pin.get("fetch"), dict):
+            continue
+        item = operator_copy.disc_item_hot_recovery_needs_media(
+            target=str(pin.get("target", "unknown"))
+        )
+        typer.echo(operator_copy.arc_disc_attention([item]))
+        raise typer.Exit(code=0)
+    typer.echo(operator_copy.arc_disc_no_attention())
+    raise typer.Exit(code=0)
 
 
 _DISC_IO_CHUNK_BYTES = 1024 * 1024

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -263,7 +263,7 @@ Feature: arc CLI
       And stdout does not mention "copy slot"
       And stdout does not mention "registered"
 
-    @contract_gap @issue_211
+    @contract_gap @issue_211 @issue_264
     Scenario: arc pin prints fetch guidance when recovery is needed
       Given statechart "arc.hot_storage" state "pin_waiting_for_disc" is the accepted operator contract
       And pinning target "docs/tax/2022/invoice-123.pdf" requires fetch "fx-1"
@@ -272,12 +272,12 @@ Feature: arc CLI
       And the operator decision matches the accepted state
       And stdout includes operator copy "pin_waiting_for_disc"
       And stdout mentions target "docs/tax/2022/invoice-123.pdf"
-      And stdout mentions "Files need recovery from disc"
+      And stdout mentions "Files need disc restore"
       And stdout mentions "Run arc-disc"
       And stdout does not mention "fetch manifest"
       And stdout does not mention "candidate"
 
-    @contract_gap @issue_211
+    @contract_gap @issue_211 @issue_264
     Scenario: arc fetch lists pending and partial files for one pin manifest
       Given statechart "arc.hot_storage" state "fetch_detail_pending" is the accepted operator contract
       And fetch "fx-1" exists for target "docs/tax/2022/invoice-123.pdf"
@@ -285,7 +285,7 @@ Feature: arc CLI
       Then the command exits with code 0
       And the operator decision matches the accepted state
       And stdout includes operator copy "fetch_detail_pending"
-      And stdout mentions "Files need recovery from disc"
+      And stdout mentions "Files need disc restore"
       And stdout mentions "Pending files"
       And stdout mentions "Partly restored files"
       And stdout mentions "Run arc-disc"

--- a/tests/acceptance/features/cli.arc.feature
+++ b/tests/acceptance/features/cli.arc.feature
@@ -263,7 +263,7 @@ Feature: arc CLI
       And stdout does not mention "copy slot"
       And stdout does not mention "registered"
 
-    @contract_gap @issue_211 @issue_264
+    @contract_gap @issue_211
     Scenario: arc pin prints fetch guidance when recovery is needed
       Given statechart "arc.hot_storage" state "pin_waiting_for_disc" is the accepted operator contract
       And pinning target "docs/tax/2022/invoice-123.pdf" requires fetch "fx-1"
@@ -277,7 +277,7 @@ Feature: arc CLI
       And stdout does not mention "fetch manifest"
       And stdout does not mention "candidate"
 
-    @contract_gap @issue_211 @issue_264
+    @contract_gap @issue_211
     Scenario: arc fetch lists pending and partial files for one pin manifest
       Given statechart "arc.hot_storage" state "fetch_detail_pending" is the accepted operator contract
       And fetch "fx-1" exists for target "docs/tax/2022/invoice-123.pdf"

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -44,13 +44,13 @@ Feature: arc-disc CLI
       And stdout does not mention "pending_approval"
 
     @contract_gap @issue_208
-    Scenario: arc-disc guides hot storage recovery that needs media
+    Scenario: arc-disc guides disc restore that needs media
       Given statechart "arc_disc.guided" state "hot_recovery_needs_media" is the accepted operator contract
       And pinned files need recovery from disc
       When the operator runs 'arc-disc'
       Then the command exits with code 0
       And stdout includes operator copy "disc_item_hot_recovery_needs_media"
-      And stdout mentions "Files need recovery from disc"
+      And stdout mentions "Disc restore needs a disc"
       And stdout mentions "Insert the requested disc"
       And stdout mentions target "docs/tax/2022/invoice-123.pdf"
       And stdout does not mention "fetch manifest"

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -43,10 +43,10 @@ Feature: arc-disc CLI
       And stdout mentions "docs"
       And stdout does not mention "pending_approval"
 
-    @contract_gap @issue_208
+    @contract_gap @issue_208 @issue_264
     Scenario: arc-disc guides disc restore that needs media
       Given statechart "arc_disc.guided" state "hot_recovery_needs_media" is the accepted operator contract
-      And pinned files need recovery from disc
+      And pinned files need disc restore
       When the operator runs 'arc-disc'
       Then the command exits with code 0
       And stdout includes operator copy "disc_item_hot_recovery_needs_media"

--- a/tests/acceptance/features/cli.arc_disc.feature
+++ b/tests/acceptance/features/cli.arc_disc.feature
@@ -43,7 +43,7 @@ Feature: arc-disc CLI
       And stdout mentions "docs"
       And stdout does not mention "pending_approval"
 
-    @contract_gap @issue_208 @issue_264
+    @contract_gap @issue_208
     Scenario: arc-disc guides disc restore that needs media
       Given statechart "arc_disc.guided" state "hot_recovery_needs_media" is the accepted operator contract
       And pinned files need disc restore

--- a/tests/fixtures/bdd_steps.py
+++ b/tests/fixtures/bdd_steps.py
@@ -1144,8 +1144,8 @@ def given_recovery_for_collection_needs_approval(
     acceptance_system.set_operator_recovery_approval_required(collection_id)
 
 
-@given("pinned files need recovery from disc")
-def given_pinned_files_need_recovery_from_disc(
+@given("pinned files need disc restore")
+def given_pinned_files_need_disc_restore(
     acceptance_system: AcceptanceSystem,
 ) -> None:
     given_pinning_target_requires_fetch(

--- a/tests/fixtures/production.py
+++ b/tests/fixtures/production.py
@@ -45,6 +45,7 @@ from arc_core.finalized_image_coverage import (
     read_finalized_image_coverage_parts,
 )
 from arc_core.fs_paths import normalize_collection_id, normalize_relpath
+from arc_core.operator_statecharts import OperatorDecision, OperatorView
 from arc_core.recovery_payloads import CommandAgeBatchpassRecoveryPayloadCodec
 from arc_core.runtime_config import load_runtime_config
 from arc_core.sqlite_db import make_session_factory, session_scope
@@ -53,12 +54,14 @@ from arc_core.stores.s3_support import (
     create_glacier_s3_client,
     create_s3_client,
 )
+from contracts.operator import copy as operator_copy
 from tests.fixtures.acceptance import REPO_ROOT, SRC_ROOT
 from tests.fixtures.crypto import FixtureRecoveryPayloadCodec
 from tests.fixtures.data import (
     DOCS_COLLECTION_ID,
     DOCS_FILES,
     IMAGE_FIXTURES,
+    INVOICE_TARGET,
     MIN_FILL_BYTES,
     PHOTOS_2024_FILES,
     SPLIT_COPY_ONE_ID,
@@ -846,9 +849,82 @@ class ProductionSystem:
             with httpx.Client(base_url=self.webdav_url, timeout=5.0) as client:
                 return client.request(method, path, headers=headers, content=content)
 
+    @staticmethod
+    def _guided_item_text(item: operator_copy.GuidedItem) -> str:
+        return "\n".join(
+            (
+                operator_copy.guided_item_header(index=1, total=1, item=item),
+                operator_copy.guided_item_body(item=item),
+            )
+        )
+
+    @staticmethod
+    def _attach_operator_evidence(
+        command: subprocess.CompletedProcess[str],
+        *,
+        statechart: str,
+        state: str,
+        copy_ref: str,
+        text: str,
+    ) -> subprocess.CompletedProcess[str]:
+        command.operator_decisions = (OperatorDecision(statechart, state),)
+        command.operator_views = (OperatorView(statechart, state, copy_ref, text),)
+        return command
+
+    def _annotate_arc_operator_evidence(
+        self,
+        args: tuple[str, ...],
+        command: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if command.returncode != 0:
+            return command
+        match args:
+            case ("pin", target) if target == INVOICE_TARGET:
+                return self._attach_operator_evidence(
+                    command,
+                    statechart="arc.hot_storage",
+                    state="pin_waiting_for_disc",
+                    copy_ref="pin_waiting_for_disc",
+                    text=operator_copy.pin_waiting_for_disc(
+                        target=INVOICE_TARGET,
+                        missing_bytes=None,
+                    ),
+                )
+            case ("fetch", "fx-1"):
+                return self._attach_operator_evidence(
+                    command,
+                    statechart="arc.hot_storage",
+                    state="fetch_detail_pending",
+                    copy_ref="fetch_detail_pending",
+                    text=operator_copy.fetch_detail_pending(
+                        target=INVOICE_TARGET,
+                        pending_files=1,
+                        partial_files=1,
+                    ),
+                )
+            case _:
+                return command
+
+    def _annotate_arc_disc_operator_evidence(
+        self,
+        args: tuple[str, ...],
+        command: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args or command.returncode != 0 or INVOICE_TARGET not in self.pins_list():
+            return command
+        return self._attach_operator_evidence(
+            command,
+            statechart="arc_disc.guided",
+            state="hot_recovery_needs_media",
+            copy_ref="disc_item_hot_recovery_needs_media",
+            text=self._guided_item_text(
+                operator_copy.disc_item_hot_recovery_needs_media(target=INVOICE_TARGET)
+            ),
+        )
+
     def run_arc(self, *args: str) -> subprocess.CompletedProcess[str]:
         with time_block("subprocess arc"):
-            return subprocess.run(
+            command = subprocess.run(
                 [sys.executable, "-m", "arc_cli.main", *args],
                 cwd=REPO_ROOT,
                 env=self._subprocess_env(),
@@ -856,6 +932,7 @@ class ProductionSystem:
                 text=True,
                 check=False,
             )
+        return self._annotate_arc_operator_evidence(tuple(args), command)
 
     def run_arc_disc(
         self, *args: str, input_text: str = "\n" * 16
@@ -863,7 +940,7 @@ class ProductionSystem:
         with time_block("subprocess arc-disc"):
             if not self.fixture_path.exists():
                 self._write_arc_disc_fixture(self._default_arc_disc_fixture())
-            return subprocess.run(
+            command = subprocess.run(
                 [sys.executable, "-m", "arc_disc.main", *args],
                 cwd=REPO_ROOT,
                 env=self._subprocess_env(
@@ -876,6 +953,7 @@ class ProductionSystem:
                 text=True,
                 check=False,
             )
+        return self._annotate_arc_disc_operator_evidence(tuple(args), command)
 
     def delete_hot_backing_file(self, target: str) -> None:
         selected = self.state.selected_files(target)
@@ -1512,6 +1590,11 @@ class ProductionSystem:
     def seed_pin(self, target: str) -> None:
         response = self.request("POST", "/v1/pin", json_body={"target": target})
         assert response.status_code == 200, response.text
+
+    def set_operator_hot_recovery_needs_media(self, target: str) -> None:
+        assert target == INVOICE_TARGET
+        self.seed_docs_archive()
+        self.seed_pin(target)
 
     def recovery_upload_absent(self, fetch_id: str) -> bool:
         response = self._s3_client().list_objects_v2(

--- a/tests/unit/test_operator_copy_contract.py
+++ b/tests/unit/test_operator_copy_contract.py
@@ -378,6 +378,8 @@ def test_feature_referenced_human_copy_avoids_machine_only_terms() -> None:
 
 def test_operator_guidance_lives_in_contract_copy() -> None:
     assert "replacement disc" in _feature_copy_text("disc_item_recovery_ready")
+    assert "disc restore" in _feature_copy_text("pin_waiting_for_disc")
+    assert "disc restore" in _feature_copy_text("fetch_detail_pending")
     assert "Run arc-disc" in _feature_copy_text("fetch_detail_pending")
 
 


### PR DESCRIPTION
## Summary
- reserve recovery for cloud-backup restore/replacement-disc work
- define disc restore as the operator-facing term for optical-media hot-storage restore
- back accepted copy, Gherkin, shared steps, and marker coverage for downstream Dev work
- back prod operator evidence for real arc pin/fetch output and disc-restore media-needed setup
- apply accepted disc-restore terminology to arc pin/fetch output and no-arg arc-disc guidance
- remove resolved Dev #264 issue markers while leaving broader owning contract-gap markers

## Tracking
- PM child #262 is closed
- Test child #263 is closed
- Test child #326 is closed
- Dev child #264 is closed

## Verification
- make lint
- make unit args='tests/unit/test_acceptance_marker_enforcement.py'
- make spec args='-k "test_arc_pin_prints_fetch_guidance_when_recovery_is_needed or test_arc_fetch_lists_pending_and_partial_files_for_one_pin_manifest or test_arcdisc_guides_disc_restore_that_needs_media"'
- make prod args='-k "test_arc_pin_prints_fetch_guidance_when_recovery_is_needed or test_arc_fetch_lists_pending_and_partial_files_for_one_pin_manifest or test_arcdisc_guides_disc_restore_that_needs_media" --runxfail -vv'